### PR TITLE
Fix error output

### DIFF
--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -71,7 +71,7 @@ class Sops():
         # sops logs always to stderr, as stdout is used for
         # file content
         if err and display:
-            display.vvvv(err)
+            display.vvvv(to_text(err, errors='surrogate_or_strict'))
 
         if exit_code > 0:
             raise SopsError(encrypted_file, exit_code, err)


### PR DESCRIPTION
### Motivation
Errors were not being displayed due to missing `to_text` on error output.

### Changes description
Add `to_text` in module_utils/sops.py.

### Additional notes
Conversation in [this pr](https://github.com/ansible-collections/community.sops/pull/6).

[Previous pull request from wrong branch](https://github.com/ansible-collections/community.sops/pull/10).
