### PR TITLE
Fix lookup sops not found

### DIFF
--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -50,13 +50,13 @@ EXAMPLES = """
 tasks:
   - name: Output secrets to screen (BAD IDEA!)
     debug:
-        msg: "Content: {{ lookup('sops', item) }}"
+        msg: "Content: {{ lookup('community.sops.sops', item) }}"
     loop:
         - sops-encrypted-file.enc.yaml
 
   - name: Add SSH private key
     copy:
-        content: "{{ lookup('sops', user + '-id_rsa') }}"
+        content: "{{ lookup('community.sops.sops', user + '-id_rsa') }}"
         dest: /home/{{ user }}/.ssh/id_rsa
         owner: "{{ user }}"
         group: "{{ user }}"


### PR DESCRIPTION
### Motivation
<!-- describe why this changes are necessary/useful -->

As noted in #16 the inline documentation in `sops` lookup plugin is wrong.

### Changes description
<!-- describe what changes are in this PR. Overview is OK, details shall be found in the git commits -->

- fix docs referencing proper FQCN

### Additional notes
<!-- any note related to these changes, please add them here -->

Thanks @ThomasSteinbach for noticing!
