### PR TITLE
Add load_vars action plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,29 @@ sops vars files would be decrypted and used.
 $ ansible-playbook playbooks/setup-server.yml -i inventory/hosts
 ```
 
+### load_vars action plugin
+
+The `load_vars` action plugin can be used similarly to Ansible's `include_vars`, except that it right now only supports single files.
+
+Examples:
+
+```
+tasks:
+  - name: Load variables from file and store them in a variable
+    community.sops.load_vars:
+        file: path/to/sops-encrypted-file.sops.yaml
+        name: variable_to_store_contents_in
+
+  - name: Load variables from file as proper variables into global namespace
+    community.sops.load_vars:
+        file: path/to/sops-encrypted-file-with-jinja2-expressions.sops.yaml
+        # The following allows to use Jinja2 expressions in the encrypted file!
+        # They are evaluated when the corresponding variable is used. This allows
+        # expressions to reference other variables defined in the same file, and
+        # also variables/facts only defined later.
+        static: false
+```
+
 ## Contributing to this collection
 
 <!--Describe how the community can contribute to your collection. At a minimum, include how and where users can create issues to report problems or request features for this collection.  List contribution requirements, including preferred workflows and necessary testing, so you can benefit from community PRs. If you are following general Ansible contributor guidelines, you can link to - [Ansible Community Guide](https://docs.ansible.com/ansible/latest/community/index.html). -->

--- a/plugins/action/load_vars.py
+++ b/plugins/action/load_vars.py
@@ -29,6 +29,7 @@ class ActionModule(ActionBase):
         if not data:
             data = dict()
         if not isinstance(data, dict):
+            # Should not happen with sops-encrypted files
             raise Exception('{0} must be stored as a dictionary/hash'.format(to_native(filename)))
         return data
 

--- a/plugins/action/load_vars.py
+++ b/plugins/action/load_vars.py
@@ -1,0 +1,98 @@
+# Copyright: (c) 2020, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from os import path, walk
+import re
+
+from ansible.module_utils.common.validation import check_type_bool, check_type_str
+from ansible.module_utils.six import iteritems, string_types
+from ansible.module_utils._text import to_native, to_text
+from ansible.plugins.action import ActionBase
+from ansible.utils.display import Display
+
+from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
+
+display = Display()
+
+
+class ActionModule(ActionBase):
+
+    _VALID_ARGS = frozenset(['file', 'name', 'static'])
+
+    def _load(self, filename):
+        output = Sops.decrypt(filename, display=display)
+
+        data = self._loader.load(output, file_name=filename, show_content=False)
+        if not data:
+            data = dict()
+        if not isinstance(data, dict):
+            raise Exception('{0} must be stored as a dictionary/hash'.format(to_native(filename)))
+        return data
+
+    def _get_option(self, name, type_name, default=None, accept_none=False):
+        value = self._task.args.get(name)
+        if value is None:
+            if accept_none:
+                return value
+            elif default is not None:
+                value = default
+            else:
+                raise Exception("Option %s must be specified" % name)
+        checkers = {
+            'str': lambda v: check_type_str(v, allow_conversion=False),
+            'bool': check_type_bool,
+        }
+        try:
+            return checkers[type_name](value)
+        except TypeError as e:
+            msg = "Value for option %s" % name
+            msg += " is of type %s and we were unable to convert to %s: %s" % (type(value), type_name, to_native(e))
+            raise Exception(msg)
+
+    def run(self, tmp=None, task_vars=None):
+        """ Load yml files recursively from a directory.
+        """
+        del tmp  # tmp no longer has any effect
+
+        result = super(ActionModule, self).run(task_vars=task_vars)
+
+        try:
+            file = to_text(self._get_option('file', 'str'))
+            name = self._get_option('name', 'str', accept_none=True)
+            if name is not None:
+                name = to_text(name)
+            static = self._get_option('static', 'bool', default=True)
+        except Exception as e:
+            result['failed'] = True
+            result['message'] = to_text(e)
+            return result
+
+        data = dict()
+        files = []
+        try:
+            filename = self._find_needle('vars', file)
+            data.update(self._load(filename))
+            files.append(filename)
+        except Exception as e:
+            result['failed'] = True
+            result['message'] = to_native(e)
+            return result
+
+        if name is None:
+            value = data
+        else:
+            value = dict()
+            value[name] = data
+
+        result['ansible_included_var_files'] = files
+        result['ansible_facts'] = value
+        result['_ansible_no_log'] = True
+
+        if not static:
+            # HACK! This tricks the strategy plugin into properly storing the result as variables, and not as (evaluated) facts
+            self._task.action = 'include_vars'
+
+        return result

--- a/plugins/modules/load_vars.py
+++ b/plugins/modules/load_vars.py
@@ -1,0 +1,80 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+author: Felix Fontein (@felixfontein)
+module: load_vars
+short_description: Load sops-encrypted variables from files, dynamically within a task
+description:
+  - Loads sops-encrypted YAML/JSON variables dynamically from a file during task runtime.
+  - To assign included variables to a different host than C(inventory_hostname),
+    use C(delegate_to) and set C(delegate_facts=yes).
+options:
+  file:
+    description:
+      - The file name from which variables should be loaded.
+      - If the path is relative, it will look for the file in C(vars/) subdirectory of a role or relative to playbook.
+    type: path
+  name:
+    description:
+      - The name of a variable into which assign the included vars.
+      - If omitted (C(null)) they will be made top level vars.
+    type: str
+  static:
+    description:
+      - If set to C(false), the contents of the file will be loaded as real variables. This means that Jinja2 expressions
+        will be interpreted on usage of the variables.
+      - If set to the default value C(true), all strings will be interpreted as strings and will not be templated,
+        neither during loading nor during usage.
+      - Please note that C(false) is not officially supported by Ansible and is achieved by hacks. We try to make sure
+        that it works for all supported versions of Ansible.
+      - "NOTE: If set to C(false), DO NOT register the result of the task! This breaks the functionality somehow.
+         (Same happens for M(ansible.builtin.include_vars).)"
+    type: bool
+    default: true
+seealso:
+- module: ansible.builtin.set_fact
+- module: ansible.builtin.include_vars
+- ref: playbooks_delegation
+  description: More information related to task delegation.
+'''
+
+EXAMPLES = r'''
+- name: Include variables of stuff.sops.yaml into the 'stuff' variable.
+  community.sops.load_vars:
+    file: stuff.sops.yaml
+    name: stuff
+    static: false  # interpret Jinja2 expressions in stuf.sops.yaml on usage of the vars!
+
+- name: Conditionally decide to load in variables into 'plans' when x is 0, otherwise do not.
+  community.sops.load_vars:
+    file: contingency_plan.sops.yaml
+    name: plans
+    static: true  # do not interpret possible Jinja2 expressions
+  when: x == 0
+
+- name: Load variables into the global namespace
+  community.sops.load_vars:
+    file: contingency_plan.sops.yaml
+'''
+
+RETURN = r'''
+ansible_facts:
+  description: Variables that were included and their values
+  returned: success
+  type: dict
+  sample: {'variable': 'value'}
+ansible_included_var_files:
+  description: A list of files that were successfully included
+  returned: success
+  type: list
+  elements: str
+  sample: [ /path/to/file.sops.yaml ]
+'''

--- a/plugins/modules/load_vars.py
+++ b/plugins/modules/load_vars.py
@@ -12,6 +12,7 @@ DOCUMENTATION = r'''
 author: Felix Fontein (@felixfontein)
 module: load_vars
 short_description: Load sops-encrypted variables from files, dynamically within a task
+version_added: '0.1.0'
 description:
   - Loads sops-encrypted YAML/JSON variables dynamically from a file during task runtime.
   - To assign included variables to a different host than C(inventory_hostname),

--- a/plugins/modules/load_vars.py
+++ b/plugins/modules/load_vars.py
@@ -36,8 +36,8 @@ options:
         neither during loading nor during usage.
       - Please note that C(false) is not officially supported by Ansible and is achieved by hacks. We try to make sure
         that it works for all supported versions of Ansible.
-      - "NOTE: If set to C(false), DO NOT register the result of the task! This breaks the functionality somehow.
-         (Same happens for M(ansible.builtin.include_vars).)"
+      - "NOTE: If set to C(false), DO NOT register the result of the task, or use this task for a loop!
+         This breaks the functionality somehow."
     type: bool
     default: true
 seealso:

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -25,6 +25,7 @@ DOCUMENTATION = '''
     vars: sops
     author: Edoardo Tenani (@endorama) <e.tenani@arduino.cc>
     short_description: Loading sops-encrypted vars files
+    version_added: '0.1.0'
     description:
         - Load encrypted YAML files into corresponding groups/hosts in group_vars/ and host_vars/ directories.
         - Files are encrypted prior to reading, making this plugin an effective companion to host_group_vars plugin.

--- a/tests/integration/targets/load_vars/aliases
+++ b/tests/integration/targets/load_vars/aliases
@@ -1,0 +1,5 @@
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/load_vars/meta/main.yml
+++ b/tests/integration/targets/load_vars/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_sops

--- a/tests/integration/targets/load_vars/tasks/main.yml
+++ b/tests/integration/targets/load_vars/tasks/main.yml
@@ -1,0 +1,87 @@
+---
+- when: sops_installed
+  block:
+    - name: Test load_vars with missing file
+      community.sops.load_vars:
+        file: non-existent.sops.yaml
+      ignore_errors: yes
+      register: load_vars_missing_file
+
+    - assert:
+        that:
+          - "load_vars_missing_file is failed"
+          - |
+            "Could not find or access 'non-existent.sops.yaml'\n" in load_vars_missing_file.message
+
+    - name: Test load_vars with non-sops file
+      community.sops.load_vars:
+        file: wrong.yaml
+      ignore_errors: yes
+      register: load_vars_wrong_file
+
+    - assert:
+        that:
+          - "load_vars_wrong_file is failed"
+          - "'sops metadata not found' in load_vars_wrong_file.message"
+
+    - name: Test load_vars with simple file into variable
+      community.sops.load_vars:
+        file: simple.sops.yaml
+        name: dest_variable
+      register: load_vars_simple
+
+    - assert:
+        that:
+          - "load_vars_simple is success"
+          - "load_vars_simple.ansible_facts == {'dest_variable': {'foo': 'bar'}}"
+          - dest_variable.foo == 'bar'
+          - foo is undefined
+
+    - name: Test load_vars with simple file into global namespace
+      community.sops.load_vars:
+        file: simple.sops.yaml
+      register: load_vars_simple_global
+
+    - assert:
+        that:
+          - "load_vars_simple_global is success"
+          - "load_vars_simple_global.ansible_facts == {'foo': 'bar'}"
+          - foo == 'bar'
+
+    - name: Test load_vars with proper vars file imported statically
+      community.sops.load_vars:
+        file: proper-vars.sops.yaml
+        static: true
+      register: load_vars_vars_static
+
+    - assert:
+        that:
+          - "load_vars_vars_static is success"
+          - test1 == '{' ~ '{ bar }' ~ '}'
+          - test2 == '{' ~ '{ to_be_defined_later }' ~ '}'
+          - bar == 'baz'
+
+    - name: Test load_vars with proper vars file imported dynamically
+      community.sops.load_vars:
+        file: proper-vars-2.sops.yaml
+        static: false
+      # MUST NOT register the result, since it breaks variable registration.
+      # This also does not work for include_vars.
+      # (https://github.com/ansible/ansible/issues/71831)
+
+    - set_fact:
+        to_be_defined_later: something_defined_later
+
+    - assert:
+        that:
+          - test1_2 == 'baz'
+          - test2_2 == 'something_defined_later'
+          - bar_2 == 'baz'
+
+    - name: Redefine to_be_defined_later
+      set_fact:
+        to_be_defined_later: something_defined_even_later
+
+    - assert:
+        that:
+          - test2_2 == 'something_defined_even_later'

--- a/tests/integration/targets/load_vars/tasks/main.yml
+++ b/tests/integration/targets/load_vars/tasks/main.yml
@@ -1,6 +1,28 @@
 ---
 - when: sops_installed
   block:
+    - name: Test load_vars with missing option
+      community.sops.load_vars:
+      ignore_errors: yes
+      register: load_vars_missing_option
+
+    - assert:
+        that:
+          - load_vars_missing_option is failed
+          - '"Option file must be specified" in load_vars_missing_option.message'
+
+    - name: Test load_vars with wrong type for option
+      community.sops.load_vars:
+        file:
+          a: b
+      ignore_errors: yes
+      register: load_vars_wrong_type
+
+    - assert:
+        that:
+          - load_vars_wrong_type is failed
+          - '"is not a string and conversion is not allowed" in load_vars_wrong_type.message'
+
     - name: Test load_vars with missing file
       community.sops.load_vars:
         file: non-existent.sops.yaml
@@ -9,7 +31,7 @@
 
     - assert:
         that:
-          - "load_vars_missing_file is failed"
+          - load_vars_missing_file is failed
           - |
             "Could not find or access 'non-existent.sops.yaml'\n" in load_vars_missing_file.message
 
@@ -21,7 +43,7 @@
 
     - assert:
         that:
-          - "load_vars_wrong_file is failed"
+          - load_vars_wrong_file is failed
           - "'sops metadata not found' in load_vars_wrong_file.message"
 
     - name: Test load_vars with simple file into variable
@@ -32,10 +54,20 @@
 
     - assert:
         that:
-          - "load_vars_simple is success"
+          - load_vars_simple is success
           - "load_vars_simple.ansible_facts == {'dest_variable': {'foo': 'bar'}}"
           - dest_variable.foo == 'bar'
           - foo is undefined
+
+    - name: Test load_vars with empty file
+      community.sops.load_vars:
+        file: empty.sops.json
+      register: load_vars_empty
+
+    - assert:
+        that:
+          - load_vars_empty is success
+          - load_vars_empty.ansible_facts | length == 0
 
     - name: Test load_vars with simple file into global namespace
       community.sops.load_vars:
@@ -44,7 +76,7 @@
 
     - assert:
         that:
-          - "load_vars_simple_global is success"
+          - load_vars_simple_global is success
           - "load_vars_simple_global.ansible_facts == {'foo': 'bar'}"
           - foo == 'bar'
 
@@ -56,7 +88,7 @@
 
     - assert:
         that:
-          - "load_vars_vars_static is success"
+          - load_vars_vars_static is success
           - test1 == '{' ~ '{ bar }' ~ '}'
           - test2 == '{' ~ '{ to_be_defined_later }' ~ '}'
           - bar == 'baz'

--- a/tests/integration/targets/load_vars/vars/.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/.sops.yaml
@@ -1,0 +1,3 @@
+---
+creation_rules:
+    - pgp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4

--- a/tests/integration/targets/load_vars/vars/empty.sops.json
+++ b/tests/integration/targets/load_vars/vars/empty.sops.json
@@ -1,0 +1,19 @@
+{
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-09-21T05:20:22Z",
+		"mac": "ENC[AES256_GCM,data:/lmY2rbeFuc9D1CvPQVWfgBsMiO9A+xDvUlO5vxovcXTrI+FHV/O8NO0VyCuXxvPpzXpsbJq9g7YjBVyllsH1Y2zveWAPNH7hoPdMTsa7g0D/qANLnkDIkr0Gj5EIi1Pek1CT631u1SPHBih60AinwulkArEWs4Z4Sh9t881jSc=,iv:CSwOl2eqZb+bw53m2GTuWdmvFYOjDlH1um5MHAB1gxg=,tag:IQ3AXbHZ1RYlHjcY0JSr9Q==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-09-21T05:20:18Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAYKF/spYZXKeQlZ0kl6RiJCcbfbRBL69jQREerUvET78Q\nqystnEdijf3Dhf0i5wrIFdSrN7uxCQISAYaxa/upklsOuoWD5tQQIVctKDfGgrSH\nVcQrcBO19PQaH6ESF0T1udbalqdjWo8UXIbVzi1aLnaPlUYuzlqPzUTbhl9H0EGE\nNThYC3tfqbsM11d/qkRkxhqyVBOlt/tMkIQZqWc3eITs6ilT1PmkBcSUdoUTpVqi\nuxuTVP5DDoMi23/AGLbXowNn36FvcytPNnMFiRQffrFOv2lBkFgfoYOGeenYfPof\nm6A+b08DlPlNJBMhtyVYo0fzWY8uJqO9NtFdxPPaHNLgAeQunj4ltnJ5644D71Tp\nceSH4Rb74ETgqOEU6eD14oSdeIXgIeWG0zzYuaCDGyU9hWLvc3SEBS8/CMMetVvx\nzKMDxxsaM+Bd5J8z8kw/c6LSUGTSaAr55XziFq0PW+Fw/QA=\n=P0+p\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
@@ -9,7 +9,7 @@ sops:
     lastmodified: '2020-09-20T20:29:19Z'
     mac: ENC[AES256_GCM,data:GMDaz9qxuB9oVJsVrQrUuK8nb9IorwdUFvkHPeanysGWFIvPDylSXK3VLTTVJLFvcSWWaAfLrWXxEE+pPXSEO6z9jB0WQaTEdLQz9rWRYP7KHL6v+Eyid9OYd8xhqAZOJnFO/jesJhvmTAAM3u8dFqqnXw+5tfyTduIs7iPdOoQ=,iv:bF2ukC11B6Oo8MnYWUlWhGxFZ8JJEyeDZSkRi4PY3Tc=,tag:0GRYGtwjwIT9wogdXm2npA==,type:str]
     pgp:
-    -   created_at: '2020-09-20T20:29:09Z'
+      - created_at: '2020-09-20T20:29:09Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 

--- a/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
@@ -1,0 +1,28 @@
+test1_2: ENC[AES256_GCM,data:iNGUgLK6RdJZQWA=,iv:FEx7YO17wTadHLcppnpElb5G5UIukfcHDatUkPzZ0rU=,tag:bKx9qwKiirzi7/lR0EQTEA==,type:str]
+test2_2: ENC[AES256_GCM,data:XuVX1GgPjLYmrQE4f3dcH59K5w2WAsXyhQ==,iv:JAAtajqwAjwG/LwEFISGnrO0fe+KKULFX5AhvL8/Hws=,tag:xOVpiXcMXe3PiCF4d/YZsQ==,type:str]
+bar_2: ENC[AES256_GCM,data:Uvwe,iv:uzyjGdPSki4QpGtwGKaqht7yPESNHojNq7vY3TGiqvc=,tag:FwG+9yFIkFWf/SItQ+NIZg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2020-09-20T20:29:19Z'
+    mac: ENC[AES256_GCM,data:GMDaz9qxuB9oVJsVrQrUuK8nb9IorwdUFvkHPeanysGWFIvPDylSXK3VLTTVJLFvcSWWaAfLrWXxEE+pPXSEO6z9jB0WQaTEdLQz9rWRYP7KHL6v+Eyid9OYd8xhqAZOJnFO/jesJhvmTAAM3u8dFqqnXw+5tfyTduIs7iPdOoQ=,iv:bF2ukC11B6Oo8MnYWUlWhGxFZ8JJEyeDZSkRi4PY3Tc=,tag:0GRYGtwjwIT9wogdXm2npA==,type:str]
+    pgp:
+    -   created_at: '2020-09-20T20:29:09Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgAXN27E1QUMoQcdyFW1D/vNJ1B022/1q8Sg+G9FbsXLTBL
+            XXLRpm+H2R8OEBT9zfW0gTp+RUcffcbEQ4zFPYghXTcfEWB18Dyz4YsemrbjW4NB
+            oHsto+5sqGAALo7grBnUeNFxp3W263YodUSbRnG8lgQeBHulK4IhOoMBr2JnRDJg
+            w/qrZBDBKQQjhl1nr6QtnKA/jlckbyw7wbtDxi8b/0w76un1gpgou+dSaF6rWo1R
+            R7gaCbOzEUm3jdIRARFPeEn7YYgm8Pacxy8krPldjHk1EDuOTL9Ubs2NGHFo2WKo
+            iZqxTPw8MhrNmWC+y90KKFx1JHmS0KLMvi5x4/cqpNLgAeQEW4NCFfCu7wZ8UvfE
+            Xcd44dol4ETgmeH8EOAy4kS1MjrgvuWQPrw+f5VRfUpd0F7RcdLmKSSn9yZ4JGoz
+            eXgIH/SWy+Bu5MgUwqKeFy/Y6BICNKdziLriOvVIYOH4dAA=
+            =VJGY
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/tests/integration/targets/load_vars/vars/proper-vars.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars.sops.yaml
@@ -1,0 +1,28 @@
+test1: ENC[AES256_GCM,data:9Pqw99u2f3qG,iv:AhLP4qOm/OVA2GuRgAxARR8t5tdxjLxU5Cqjq2rSalU=,tag:6mKhNKuv7SQ43SiL1FcrPg==,type:str]
+test2: ENC[AES256_GCM,data:SS8y/zN8p6KctIk4KRfn3Q6nos5fsglewg==,iv:zSQm0reZ8d+0IQAGkCyb4VENtRcNN1MOW7Yu8fcHe2Y=,tag:5kl1ofM+Am50+opkoXBsvA==,type:str]
+bar: ENC[AES256_GCM,data:l4r5,iv:bxtHopVoSImLBY0u+1FUPe5qwJGk9nfy2ODI4vYhgiI=,tag:FjdNMkU0YFisswXbgEjCjA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2020-09-20T20:07:56Z'
+    mac: ENC[AES256_GCM,data:AaweBPIMuppybdu2dOzQlFPB9+D0nwg3XBtHQ/Caffnk7IhTBkuIvG7FOYSOmsXGij+wDReunVAeIDdjrlF1jB7FulerQQQJ/Uvz188yVUiwrXUDqA8Vi1WJzpIU35w5JeukI5kyYSWrtTv8Rc5RIe37GgvZOoEicFQjh3mL9pE=,iv:yL9cWmS32YBurY2siO6mxI0cW93OZbBlHiemLByIsM4=,tag:p6muGvdSYtfz9LmVHt7Rtg==,type:str]
+    pgp:
+    -   created_at: '2020-09-20T20:07:20Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgAkSnBl8glONDFOH6XOjo9YbfYCf3L/i8aYueZ/O9VlIX8
+            uyG5JzSfhQu0Yy9BXwuZfELo54SvxqQvlTIF0lQ3VDjBVcZgosaxN+yvMsB9jn6b
+            gbdK0nqduXcwuZGUJqcnq8TBixiWQI+oFMSQUsHrA4O0IqDb0UzGcTDMmVv0FqZu
+            p3C5Femn1z1E/QqLKRU2YGAHbbfBVdNkQiAFAvT6AlchnvNEIyaLeS3D8yueIrBR
+            B76/YNsjSVUff1ZnHm2B0zn/HnC+vQQuMLDnKrQffXJHRJ2AEt0lls/al+NXLiOm
+            TlkE0F6/ZGPIfznt9+tpXhUyAXsOpEZXWYPIfrheodLgAeS3rZfS0Ey7RI02QSq0
+            Jk/g4dSl4DjgAOGcW+Dl4gnGdMjgUuV1tnG4e5riZleM7a+5TSoWZWIJFJqAXO/6
+            EqdSmUvN2uAS5O3DU0mrnMTHTDX4Ghjorh3iPwK2++GT8QA=
+            =SfPv
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/tests/integration/targets/load_vars/vars/proper-vars.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars.sops.yaml
@@ -9,7 +9,7 @@ sops:
     lastmodified: '2020-09-20T20:07:56Z'
     mac: ENC[AES256_GCM,data:AaweBPIMuppybdu2dOzQlFPB9+D0nwg3XBtHQ/Caffnk7IhTBkuIvG7FOYSOmsXGij+wDReunVAeIDdjrlF1jB7FulerQQQJ/Uvz188yVUiwrXUDqA8Vi1WJzpIU35w5JeukI5kyYSWrtTv8Rc5RIe37GgvZOoEicFQjh3mL9pE=,iv:yL9cWmS32YBurY2siO6mxI0cW93OZbBlHiemLByIsM4=,tag:p6muGvdSYtfz9LmVHt7Rtg==,type:str]
     pgp:
-    -   created_at: '2020-09-20T20:07:20Z'
+      - created_at: '2020-09-20T20:07:20Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 

--- a/tests/integration/targets/load_vars/vars/simple.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/simple.sops.yaml
@@ -1,0 +1,25 @@
+foo: ENC[AES256_GCM,data:a25L,iv:X8ILHZr+YiyLWa90Y+cwoMD1nVuel7JyTs0A5+oiOOo=,tag:GbBtp+Yqx1KEjdyztqS4EQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2020-02-20T10:44:32Z'
+    mac: ENC[AES256_GCM,data:BAwQqD9sHgHkmlxPQLKq28Xy48qPp1B/+GDLEsIxir6WNhZgw8OgjVF1u/wCAad6qHkmN02Bwenr+aay6uKfCuOEsTRSvZ7v80yAU+h0wL3zJ/KMkRsE3QP3CWxcLQxInt+YaBjR+Q0IUjDXKm3u6ZomixZe5F5pwWr36ErV6Y0=,iv:e/iiyXQiCh8C2w/bc8mr/Psv+ehmqEMqEC1/bbGFHpY=,tag:NSDo2HISIBJhYvsqrU0mSA==,type:str]
+    pgp:
+      - created_at: '2020-02-20T10:44:32Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgALJTUwdx6rAPckJ+reP5TEq+lXzHI1Zi7aHYOqZQBnA2s
+            z8h1gRce/fn7RPkmdsjsdSYmxGGKqwDXxUYsbN1aWXk6mb4Juktdvjl/GndF6PkU
+            TiN/l1GM6upgS+GPxA01NKsGkVmEtKR5NhsNEnE6OzY29+PFLsBX2vO1Zfg7kzBz
+            cDl6PT8fbFTEaFeyuYl9IslIV8yYsj1oHL3CF76RjCP6b18NSOHM23ytlH+KVaBV
+            ntoSVkTyWDx5o9iEHBEWSEGNpaCWWiEgkDEkA1VqMHdUlsW+IjZ8ggg5NJbcVtrG
+            YkN8rlGsNEzx+g4O4b1160A2K6AdTBcoGHwHD3u3XdLgAeTqT1ekE2N3yNT6w4sm
+            6uET4eTS4Cvg1OFCgOC34uUzlY3gbuVy20h8RNyQoAfhSN4DD2MexKqcMMCVCtn0
+            OhRMTP2jjOCe5Ex3/p3awcVxwx7qeJ26Vnfiwtg6ueFI5AA=
+            =tcnq
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.4.0

--- a/tests/integration/targets/load_vars/vars/wrong.yaml
+++ b/tests/integration/targets/load_vars/vars/wrong.yaml
@@ -1,0 +1,2 @@
+---
+this-is-not: a sops file


### PR DESCRIPTION
### Motivation
It would be nice to be able to use `vars_files` and `include_vars` with sops-encrypted YAML/JSON files. Unfortunately, that does not work, since there are no vault plugins yets (both directives/actions work with raw files and Ansible Vault, but not with anything else).

### Changes description
This adds a simple `load_vars` plugin, which behaves similarly to `include_vars`, but decodes sops-encrypted YAML/JSON files.

It only imports the file parts of `include_vars`, not the directory parts.

Also, by default, it does NOT treat the loaded values as variables, but as facts. This can be changed by setting `static: false`, but this functionality relies on a hack. I used another name (I originally wanted to use `include_sops_vars`) so the "proper" name can be used once this can be properly implemented without a hack.
