### PR TITLE
Fix plugin sanity tests

### DIFF
--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -22,7 +22,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = """
-    lookup: sops
+    name: sops
     author: Edoardo Tenani (@endorama) <e.tenani@arduino.cc>
     short_description: Read sops encrypted file contents
     version_added: '0.1.0'

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -22,7 +22,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 DOCUMENTATION = '''
-    vars: sops
+    name: sops
     author: Edoardo Tenani (@endorama) <e.tenani@arduino.cc>
     short_description: Loading sops-encrypted vars files
     version_added: '0.1.0'


### PR DESCRIPTION
##### SUMMARY
According to https://github.com/ansible/ansible/issues/71795, `<plugin_type>:` should be replaced by `name:` in the plugin docs.

I marked this as [WIP] since it should wait until ansible/ansible#71734 is finalized.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
collection
