### PR TITLE
Add sops_encrypt module

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,45 @@ tasks:
         static: false
 ```
 
+### encrypt_sops module
+
+The `encrypt_sops` module can be used to create and update sops encrypted files. It assumes that sops is configured via environment variables or a `.sops.yaml` file.
+
+Examples:
+
+```
+tasks:
+  - name: Store secret text sops encrypted
+    community.sops.encrypt_sops:
+        path: path/to/sops-encrypted-file.sops
+        content_text: This is some secret text.
+
+  - name: Store secret binary data sops encrypted
+    community.sops.encrypt_sops:
+        path: path/to/sops-encrypted-file.sops
+        content_binary: "{{ some_secret_binary_data | b64encode }}"
+
+  - name: Store secret JSON data
+    community.sops.encrypt_sops:
+        path: path/to/sops-encrypted-file.sops.json
+        content_json:
+            key1: value1
+            key2:
+                - value2
+                - key3: value3
+                  key4: value5
+
+  - name: Store secret YAML data
+    community.sops.encrypt_sops:
+        path: path/to/sops-encrypted-file.sops.yaml
+        content_yaml:
+            key1: value1
+            key2:
+                - value2
+                - key3: value3
+                  key4: value5
+```
+
 ## Contributing to this collection
 
 <!--Describe how the community can contribute to your collection. At a minimum, include how and where users can create issues to report problems or request features for this collection.  List contribution requirements, including preferred workflows and necessary testing, so you can benefit from community PRs. If you are following general Ansible contributor guidelines, you can link to - [Ansible Community Guide](https://docs.ansible.com/ansible/latest/community/index.html). -->

--- a/plugins/module_utils/io.py
+++ b/plugins/module_utils/io.py
@@ -1,0 +1,52 @@
+# Copyright (c), Yanis Guenane <yanis+ansible@guenane.org>, 2016
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+import os
+import tempfile
+
+
+# This is taken from community.crypto
+
+def write_file(module, content):
+    '''
+    Writes content into destination file as securely as possible.
+    Uses file arguments from module.
+    '''
+    # Find out parameters for file
+    file_args = module.load_file_common_arguments(module.params)
+    # Create tempfile name
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix=b'.ansible_tmp')
+    try:
+        os.close(tmp_fd)
+    except Exception:
+        pass
+    module.add_cleanup_file(tmp_name)  # if we fail, let Ansible try to remove the file
+    try:
+        try:
+            # Create tempfile
+            file = os.open(tmp_name, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            os.write(file, content)
+            os.close(file)
+        except Exception as e:
+            try:
+                os.remove(tmp_name)
+            except Exception:
+                pass
+            module.fail_json(msg='Error while writing result into temporary file: {0}'.format(e))
+        # Update destination to wanted permissions
+        if os.path.exists(file_args['path']):
+            module.set_fs_attributes_if_different(file_args, False)
+        # Move tempfile to final destination
+        module.atomic_move(tmp_name, file_args['path'])
+        # Try to update permissions again
+        module.set_fs_attributes_if_different(file_args, False)
+    except Exception as e:
+        try:
+            os.remove(tmp_name)
+        except Exception:
+            pass
+        module.fail_json(msg='Error while writing result: {0}'.format(e))

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -1,5 +1,4 @@
 # Copyright (c), Edoardo Tenani <e.tenani@arduino.cc>, 2018-2020
-# Copyright (c), Yanis Guenane <yanis+ansible@guenane.org>, 2016
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 from __future__ import absolute_import, division, print_function
@@ -9,9 +8,6 @@ __metaclass__ = type
 from ansible.module_utils._text import to_text, to_native
 
 from subprocess import Popen, PIPE
-
-import os
-import tempfile
 
 
 # From https://github.com/mozilla/sops/blob/master/cmd/sops/codes/codes.go
@@ -110,44 +106,3 @@ class Sops():
             raise SopsError('to stdout', exit_code, err, decryption=False)
 
         return output
-
-
-def write_file(module, content):
-    '''
-    Writes content into destination file as securely as possible.
-    Uses file arguments from module.
-    '''
-    # Find out parameters for file
-    file_args = module.load_file_common_arguments(module.params)
-    # Create tempfile name
-    tmp_fd, tmp_name = tempfile.mkstemp(prefix=b'.ansible_tmp')
-    try:
-        os.close(tmp_fd)
-    except Exception:
-        pass
-    module.add_cleanup_file(tmp_name)  # if we fail, let Ansible try to remove the file
-    try:
-        try:
-            # Create tempfile
-            file = os.open(tmp_name, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-            os.write(file, content)
-            os.close(file)
-        except Exception as e:
-            try:
-                os.remove(tmp_name)
-            except Exception:
-                pass
-            module.fail_json(msg='Error while writing result into temporary file: {0}'.format(e))
-        # Update destination to wanted permissions
-        if os.path.exists(file_args['path']):
-            module.set_fs_attributes_if_different(file_args, False)
-        # Move tempfile to final destination
-        module.atomic_move(tmp_name, file_args['path'])
-        # Try to update permissions again
-        module.set_fs_attributes_if_different(file_args, False)
-    except Exception as e:
-        try:
-            os.remove(tmp_name)
-        except Exception:
-            pass
-        module.fail_json(msg='Error while writing result: {0}'.format(e))

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -44,12 +44,14 @@ SOPS_ERROR_CODES = {
 class SopsError(Exception):
     ''' Extend Exception class with sops specific informations '''
 
-    def __init__(self, filename, exit_code, message):
+    def __init__(self, filename, exit_code, message, decryption=True):
         if exit_code in SOPS_ERROR_CODES:
             exception_name = SOPS_ERROR_CODES[exit_code]
-            message = "error with file %s: %s exited with code %d: %s" % (filename, exception_name, exit_code, to_native(message))
+            message = "error with file %s: %s exited with code %d: %s" % (
+                filename, exception_name, exit_code, to_native(message))
         else:
-            message = "could not decrypt file %s; Unknown sops error code: %s" % (filename, to_native(exit_code))
+            message = "could not %s file %s; Unknown sops error code: %s; message: %s" % (
+                'decrypt' if decryption else 'encrypt', filename, exit_code, to_native(message))
         super(SopsError, self).__init__(message)
 
 
@@ -80,9 +82,27 @@ class Sops():
             display.vvvv(to_text(err, errors='surrogate_or_strict'))
 
         if exit_code > 0:
-            raise SopsError(encrypted_file, exit_code, err)
+            raise SopsError(encrypted_file, exit_code, err, decryption=True)
 
         if rstrip:
             output = output.rstrip()
+
+        return output
+
+    @staticmethod
+    def encrypt(data, display=None, cwd=None):
+        # Run sops directly, python module is deprecated
+        command = ["sops", "--encrypt", "/dev/stdin"]
+        process = Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd)
+        (output, err) = process.communicate(input=data)
+        exit_code = process.returncode
+
+        # sops logs always to stderr, as stdout is used for
+        # file content
+        if err and display:
+            display.vvvv(to_text(err, errors='surrogate_or_strict'))
+
+        if exit_code > 0:
+            raise SopsError('to stdout', exit_code, err, decryption=False)
 
         return output

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -92,11 +92,12 @@ class Sops():
     @staticmethod
     def encrypt(data, display=None, cwd=None, input_type=None, output_type=None):
         # Run sops directly, python module is deprecated
-        command = ["sops", "--encrypt", "/dev/stdin"]
+        command = ["sops"]
         if input_type is not None:
             command.extend(["--input-type", input_type])
         if output_type is not None:
             command.extend(["--output-type", output_type])
+        command.extend(["--encrypt", "/dev/stdin"])
         process = Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd)
         (output, err) = process.communicate(input=data)
         exit_code = process.returncode

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -1,4 +1,5 @@
 # Copyright (c), Edoardo Tenani <e.tenani@arduino.cc>, 2018-2020
+# Copyright (c), Yanis Guenane <yanis+ansible@guenane.org>, 2016
 # Simplified BSD License (see licenses/simplified_bsd.txt or https://opensource.org/licenses/BSD-2-Clause)
 
 from __future__ import absolute_import, division, print_function
@@ -8,6 +9,9 @@ __metaclass__ = type
 from ansible.module_utils._text import to_text, to_native
 
 from subprocess import Popen, PIPE
+
+import os
+import tempfile
 
 
 # From https://github.com/mozilla/sops/blob/master/cmd/sops/codes/codes.go
@@ -106,3 +110,44 @@ class Sops():
             raise SopsError('to stdout', exit_code, err, decryption=False)
 
         return output
+
+
+def write_file(module, content):
+    '''
+    Writes content into destination file as securely as possible.
+    Uses file arguments from module.
+    '''
+    # Find out parameters for file
+    file_args = module.load_file_common_arguments(module.params)
+    # Create tempfile name
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix=b'.ansible_tmp')
+    try:
+        os.close(tmp_fd)
+    except Exception:
+        pass
+    module.add_cleanup_file(tmp_name)  # if we fail, let Ansible try to remove the file
+    try:
+        try:
+            # Create tempfile
+            file = os.open(tmp_name, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            os.write(file, content)
+            os.close(file)
+        except Exception as e:
+            try:
+                os.remove(tmp_name)
+            except Exception:
+                pass
+            module.fail_json(msg='Error while writing result into temporary file: {0}'.format(e))
+        # Update destination to wanted permissions
+        if os.path.exists(file_args['path']):
+            module.set_fs_attributes_if_different(file_args, False)
+        # Move tempfile to final destination
+        module.atomic_move(tmp_name, file_args['path'])
+        # Try to update permissions again
+        module.set_fs_attributes_if_different(file_args, False)
+    except Exception as e:
+        try:
+            os.remove(tmp_name)
+        except Exception:
+            pass
+        module.fail_json(msg='Error while writing result: {0}'.format(e))

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -90,9 +90,13 @@ class Sops():
         return output
 
     @staticmethod
-    def encrypt(data, display=None, cwd=None):
+    def encrypt(data, display=None, cwd=None, input_type=None, output_type=None):
         # Run sops directly, python module is deprecated
         command = ["sops", "--encrypt", "/dev/stdin"]
+        if input_type is not None:
+            command.extend(["--input-type", input_type])
+        if output_type is not None:
+            command.extend(["--output-type", output_type])
         process = Popen(command, stdin=PIPE, stdout=PIPE, stderr=PIPE, cwd=cwd)
         (output, err) = process.communicate(input=data)
         exit_code = process.returncode

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -97,6 +97,18 @@ except ImportError:
     yaml = None
 
 
+def get_data_type(module):
+    if module.params['content_text'] is not None:
+        return 'binary'
+    if module.params['content_binary'] is not None:
+        return 'binary'
+    if module.params['content_json'] is not None:
+        return 'json'
+    if module.params['content_yaml'] is not None:
+        return 'yaml'
+    module.fail_json(msg='Internal error: unknown content type')
+
+
 def compare_encoded_content(module, binary_data, content):
     if module.params['content_text'] is not None:
         return content == module.params['content_text'].encode('utf-8')
@@ -174,7 +186,7 @@ def main():
             changed = True
         else:
             # Change detection: check if encrypted data equals new data
-            decrypted_content = Sops.decrypt(path, decode_output=False, rstrip=False)
+            decrypted_content = Sops.decrypt(path, decode_output=False, output_type=get_data_type(module), rstrip=False)
             if not compare_encoded_content(module, binary_data, decrypted_content):
                 changed = True
 

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -85,7 +85,8 @@ import traceback
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_text
 
-from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError, write_file
+from ansible_collections.community.sops.plugins.module_utils.io import write_file
+from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
 
 try:
     import yaml

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -53,7 +53,7 @@ options:
 extends_documentation_fragment:
 - ansible.builtin.files
 seealso:
-- ref: ansible_collections.community.sops.sops_lookup
+- ref: community.sops.sops lookup <ansible_collections.community.sops.sops_lookup>
   description: The sops lookup can be used decrypt sops-encrypted files.
 '''
 

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -82,9 +82,8 @@ import json
 import os
 import traceback
 
-from ansible.module_utils.basic import AnsibleModule
-from ansible.module_utils.six.moves.urllib.parse import urlencode
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.basic import AnsibleModule, missing_required_lib
+from ansible.module_utils._text import to_text
 
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError, write_file
 
@@ -106,13 +105,15 @@ def compare_encoded_content(module, binary_data, content):
         # Compare JSON
         try:
             return json.loads(content) == module.params['content_json']
-        except:
+        except Exception as dummy:
+            # Treat parsing errors as content not equal
             return False
     if module.params['content_yaml'] is not None:
         # Compare YAML
         try:
             return yaml.loads(content) == module.params['content_yaml']
-        except:
+        except Exception as dummy:
+            # Treat parsing errors as content not equal
             return False
     module.fail_json(msg='Internal error: unknown content type')
 

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -1,0 +1,192 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# (c) 2020, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = r'''
+---
+author: Felix Fontein (@felixfontein)
+module: sops_encrypt
+short_description: Encrypt data with sops
+version_added: '0.1.0'
+description:
+  - Allows to encrypt binary data (Base64 encoded), text data, JSON or YAML data with sops.
+options:
+  path:
+    description:
+      - The sops encrypt file.
+    type: path
+    required: true
+  force:
+    description:
+      - Force rewriting the encrypted file.
+    type: bool
+    default: false
+  content_text:
+    description:
+      - The data to encrypt. Must be a Unicode text.
+      - Please note that the module might not be idempotent if the text can be parsed as JSON or YAML.
+      - Exactly one of I(content_text), I(content_binary), I(content_json) and I(content_yaml) must be specified.
+    type: str
+  content_binary:
+    description:
+      - The data to encrypt. Must be L(Base64 encoded,https://en.wikipedia.org/wiki/Base64) binary data.
+      - Please note that the module might not be idempotent if the data can be parsed as JSON or YAML.
+      - Exactly one of I(content_text), I(content_binary), I(content_json) and I(content_yaml) must be specified.
+    type: str
+  content_json:
+    description:
+      - The data to encrypt. Must be a JSON dictionary.
+      - Exactly one of I(content_text), I(content_binary), I(content_json) and I(content_yaml) must be specified.
+    type: dict
+  content_yaml:
+    description:
+      - The data to encrypt. Must be a YAML dictionary.
+      - Please note that Ansible only allows to pass data that can be represented as a JSON dictionary.
+      - Exactly one of I(content_text), I(content_binary), I(content_json) and I(content_yaml) must be specified.
+    type: dict
+extends_documentation_fragment:
+- ansible.builtin.files
+seealso:
+- ref: ansible_collections.community.sops.sops_lookup
+  description: The sops lookup can be used decrypt sops-encrypted files.
+'''
+
+EXAMPLES = r'''
+- name: Encrypt a secret text.
+  community.sops.sops_encrypt:
+    path: text-data.sops
+    content_text: This is a secret text.
+
+- name: Encrypt the contents of a file
+  community.sops.sops_encrypt:
+    path: binary-data.sops
+    content_binary: "{{ lookup('ansible.builtin.file', '/path/to/file', rstrip=false) | b64encode }}"
+
+- name: Encrypt some datastructure as YAML
+  community.sops.sops_encrypt:
+    path: stuff.sops.yaml
+    content_yaml: "{{ result }}"
+'''
+
+RETURN = r''' # '''
+
+
+import base64
+import json
+import os
+import traceback
+
+from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.six.moves.urllib.parse import urlencode
+from ansible.module_utils._text import to_native, to_text
+
+from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError, write_file
+
+try:
+    import yaml
+    HAS_YAML = True
+except ImportError:
+    YAML_IMP_ERR = traceback.format_exc()
+    HAS_YAML = False
+    yaml = None
+
+
+def compare_encoded_content(module, binary_data, content):
+    if module.params['content_text'] is not None:
+        return content == module.params['content_text'].encode('utf-8')
+    if module.params['content_binary'] is not None:
+        return content == binary_data
+    if module.params['content_json'] is not None:
+        # Compare JSON
+        try:
+            return json.loads(content) == module.params['content_json']
+        except:
+            return False
+    if module.params['content_yaml'] is not None:
+        # Compare YAML
+        try:
+            return yaml.loads(content) == module.params['content_yaml']
+        except:
+            return False
+    module.fail_json(msg='Internal error: unknown content type')
+
+
+def get_encoded_content(module, binary_data):
+    if module.params['content_text'] is not None:
+        return module.params['content_text'].encode('utf-8')
+    if module.params['content_binary'] is not None:
+        return binary_data
+    if module.params['content_json'] is not None:
+        return json.dumps(module.params['content_json']).encode('utf-8')
+    if module.params['content_yaml'] is not None:
+        return yaml.safe_dump(module.params['content_yaml']).encode('utf-8')
+    module.fail_json(msg='Internal error: unknown content type')
+
+
+def main():
+    argument_spec = dict(
+        path=dict(type='path', required=True),
+        force=dict(type='bool', default=False),
+        content_text=dict(type='str', no_log=True),
+        content_binary=dict(type='str', no_log=True),
+        content_json=dict(type='dict', no_log=True),
+        content_yaml=dict(type='dict', no_log=True),
+    )
+    module = AnsibleModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[
+            ('content_text', 'content_binary', 'content_json', 'content_yaml'),
+        ],
+        required_one_of=[
+            ('content_text', 'content_binary', 'content_json', 'content_yaml'),
+        ],
+        supports_check_mode=True,
+        add_file_common_args=True,
+    )
+
+    # Check YAML
+    if module.params['content_yaml'] is not None and not HAS_YAML:
+        module.fail_json(msg=missing_required_lib('pyyaml'), exception=YAML_IMP_ERR)
+
+    # Decode binary data
+    binary_data = None
+    if module.params['content_binary'] is not None:
+        try:
+            binary_data = base64.b64decode(module.params['content_binary'])
+        except Exception as e:
+            module.fail_json(msg='Cannot decode Base64 encoded data: {0}'.format(e))
+
+    path = module.params['path']
+    directory = os.path.dirname(path) or None
+    changed = False
+
+    try:
+        if module.params['force'] or not os.path.exists(path):
+            # Simply encrypt
+            changed = True
+        else:
+            # Change detection: check if encrypted data equals new data
+            decrypted_content = Sops.decrypt(path, decode_output=False, rstrip=False)
+            if not compare_encoded_content(module, binary_data, decrypted_content):
+                changed = True
+
+        if changed and not module.check_mode:
+            data = Sops.encrypt(data=get_encoded_content(module, binary_data), cwd=directory)
+            write_file(module, data)
+    except SopsError as e:
+        module.fail_json(msg=to_text(e))
+
+    file_args = module.load_file_common_arguments(module.params)
+    changed = module.set_fs_attributes_if_different(file_args, changed)
+
+    module.exit_json(changed=changed)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/sops_encrypt/aliases
+++ b/tests/integration/targets/sops_encrypt/aliases
@@ -1,0 +1,4 @@
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd

--- a/tests/integration/targets/sops_encrypt/files/.sops.yaml
+++ b/tests/integration/targets/sops_encrypt/files/.sops.yaml
@@ -1,0 +1,3 @@
+---
+creation_rules:
+    - pgp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4

--- a/tests/integration/targets/sops_encrypt/files/broken-json-yaml
+++ b/tests/integration/targets/sops_encrypt/files/broken-json-yaml
@@ -1,0 +1,20 @@
+{
+	"data": "ENC[AES256_GCM,data:Gw==,iv:zVZEcknNNtMsjB7jLYUZglzdLIrHS658uwjOD4Kth6A=,tag:gzP41dCGjBAedV+XiQFepw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-07T19:25:02Z",
+		"mac": "ENC[AES256_GCM,data:KnhqQH9rRqJ0XC40qhI79WtNBSiE9ym3SO58Bw09Bev9kq6uMVxAm9iOZvjQazOupELHaJiLO6fWT3FCoZfiU0IJBkN8JzFsKr2C59UH4B8f0RJZhNrAJ3AriBFPateFneDbrwjld0xEhP+2f286yIFv/xc/DEEPduIKRvkVN4I=,iv:yg06T0+gQ4j+bF3NAxQqwwPlJGBCcHTV6APzKT1x334=,tag:cVQ7oAh0HJ2rM8b6gVpdUg==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-07T19:24:59Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgApb3VzPV0KmRyGRSiqPVRaM0cBthJtHu9H22QGXFAb8X/\nBLPXFBlFoFKbg9eUzG0EfKDzF1f5Aeeme3Fq6cGjmtU1oyynQLFtb3369zAC+Itf\nZo3u8pjC8YDPg2NpEFrAg4YZgVIr56UdEjjC4CDvzgYd08WCIYABIO6iedSneTh2\nBcqCDc5WY5vzUnon29kUnpolOPHXjDE3PHCynbdoELrlYY3lmw4ymD0sBdtcBDER\nAtM4s3Xz7C5XhF134GmxMdQ5P/QdxSR2L1vgludDs8/Q62OxSGw3vnLXFXkHmaBQ\nxYrt+0ehNAreL/TaR5em0Bu3Bk00RxmQnrUFLc1G2dLgAeRUspltx0tjMT7eiBxx\nwQ0I4W5u4PvgVOGSG+Bp4uin1nXgduUcQnRT3Dmr1EpBbDAhZ9ldlthrxk7Ir15H\ndEJxe7jtsOAk5HlYOWliZOyFb2JtqtNqMGjimD4JPeEXOgA=\n=eh24\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/sops_encrypt/files/wrong.yaml
+++ b/tests/integration/targets/sops_encrypt/files/wrong.yaml
@@ -1,0 +1,2 @@
+---
+this-is-not: a sops file

--- a/tests/integration/targets/sops_encrypt/meta/main.yml
+++ b/tests/integration/targets/sops_encrypt/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_sops

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -29,6 +29,20 @@
             - value3.3
             - value3.4
 
+    # Invalid Base64
+
+    - name: Create binary file
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_bad_base64"
+        content_binary: This is not Base64
+      ignore_errors: true
+      register: result_not_base64
+
+    - assert:
+        that:
+          - result_not_base64 is failed
+          - '"Cannot decode Base64 encoded data" in result_not_base64.msg'
+
     # Broken file overwrite
 
     - name: Place broken file
@@ -241,6 +255,17 @@
     - set_fact:
         value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_json') | from_json }}"
 
+    - name: Place broken JSON file
+      copy:
+        src: "broken-json-yaml"
+        dest: "{{ output_dir }}/test_json_broken"
+
+    - name: Update broken JSON file
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_json_broken"
+        content_json: "{{ json_value_1 }}"
+      register: result_broken_change
+
     - assert:
         that:
           - result_check is changed
@@ -252,6 +277,7 @@
           - result_change_check is changed
           - result_change is changed
           - value_2 == json_value_2
+          - result_broken_change is changed
 
     # YAML content
 
@@ -301,9 +327,16 @@
     - set_fact:
         value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml') | from_yaml }}"
 
-    - debug: var=value_1_raw
-    - debug: var=value_1
-    - debug: var=value_2
+    - name: Place broken YAML file
+      copy:
+        src: "broken-json-yaml"
+        dest: "{{ output_dir }}/test_yaml_broken"
+
+    - name: Update broken YAML file
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_yaml_broken"
+        content_json: "{{ json_value_1 }}"
+      register: result_broken_change
 
     - assert:
         that:
@@ -316,3 +349,28 @@
           - result_change_check is changed
           - result_change is changed
           - value_2 == json_value_2
+          - result_broken_change is changed
+
+    # Output type JSON
+
+    - name: Create text file with output type JSON
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_output_type.json"
+        content_text: "{{ text_value_1 }}"
+      register: result
+
+    - set_fact:
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_output_type.json', rstrip=False) | from_json }}"
+        value_2: "{{ lookup('ansible.builtin.file', output_dir ~ '/test_output_type.json', rstrip=False) }}"
+
+    - name: Create text file with output type JSON (idempotency)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_output_type.json"
+        content_text: "{{ text_value_1 }}"
+      register: result_idem
+
+    - assert:
+        that:
+          - result_idem is not changed
+          - value_1.data == text_value_1
+          - value_2.startswith('{')

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -6,6 +6,17 @@
         src: ".sops.yaml"
         dest: "{{ output_dir }}/.sops.yaml"
 
+    - name: Define test objects
+      set_fact:
+        text_value_1: This is a text.
+        text_value_2: |+
+          This is another text!
+
+          it has two newlines at the end.
+
+        binary_value_1_b64: 'AQIDAAQ='
+        binary_value_2_b64: 'AQIDAAQgCg=='
+
     # Broken file overwrite
 
     - name: Place broken file
@@ -59,14 +70,14 @@
     - name: Create text file (check mode)
       community.sops.sops_encrypt:
         path: "{{ output_dir }}/test"
-        content_text: This is a text.
+        content_text: "{{ text_value_1 }}"
       check_mode: true
       register: result_check
 
     - name: Create text file
       community.sops.sops_encrypt:
         path: "{{ output_dir }}/test"
-        content_text: This is a text.
+        content_text: "{{ text_value_1 }}"
       register: result
 
     - set_fact:
@@ -75,35 +86,27 @@
     - name: Create text file (idempotency, check mode)
       community.sops.sops_encrypt:
         path: "{{ output_dir }}/test"
-        content_text: This is a text.
+        content_text: "{{ text_value_1 }}"
       check_mode: true
       register: result_idempotent_check
 
     - name: Create text file (idempotency)
       community.sops.sops_encrypt:
         path: "{{ output_dir }}/test"
-        content_text: This is a text.
+        content_text: "{{ text_value_1 }}"
       register: result_idempotent
 
     - name: Create text file (change, check mode)
       community.sops.sops_encrypt:
         path: "{{ output_dir }}/test"
-        content_text: |+
-          This is another text!
-
-          it has two newlines at the end.
-
+        content_text: "{{ text_value_2 }}"
       check_mode: true
       register: result_change_check
 
     - name: Create text file (change)
       community.sops.sops_encrypt:
         path: "{{ output_dir }}/test"
-        content_text: |+
-          This is another text!
-
-          it has two newlines at the end.
-
+        content_text: "{{ text_value_2 }}"
       register: result_change
 
     - set_fact:
@@ -113,18 +116,14 @@
         that:
           - result_check is changed
           - result is changed
-          - value_1 == 'This is a text.'
+          - value_1 == text_value_1
           - result_idempotent_check is not changed
           - result_idempotent is not changed
           - result_change_check is changed
           - result_change is changed
-          - value_2 == 'This is another text!\n\nit has two newlines at the end.\n\n'
+          - value_2 == text_value_2
 
     # Binary content
-
-    - set_fact:
-        binary_value_1_b64: 'AQIDAAQ='
-        binary_value_2_b64: 'AQIDAAQgCg=='
 
     - name: Create binary file (check mode)
       community.sops.sops_encrypt:

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -6,6 +6,56 @@
         src: ".sops.yaml"
         dest: "{{ output_dir }}/.sops.yaml"
 
+    # Broken file overwrite
+
+    - name: Place broken file
+      copy:
+        dest: "{{ output_dir }}/broken"
+        content: I'm not sops encrypted
+
+    - name: Cannot decode existing file (overwrite, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/broken"
+        content_text: Test
+      ignore_errors: yes
+      register: result_cannot_decode_check
+      check_mode: true
+
+    - name: Cannot decode existing file (overwrite)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/broken"
+        content_text: Test
+      ignore_errors: yes
+      register: result_cannot_decode
+
+    - name: Cannot decode existing file (force, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/broken"
+        content_text: Test
+        force: true
+      register: result_cannot_decode_force_check
+      check_mode: true
+
+    - name: Cannot decode existing file (force)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/broken"
+        content_text: Test
+        force: true
+      register: result_cannot_decode_force
+
+    - set_fact:
+        value: "{{ lookup('community.sops.sops', output_dir ~ '/broken', rstrip=False) }}"
+
+    - assert:
+        that:
+          - result_cannot_decode_check is failed
+          - result_cannot_decode is failed
+          - result_cannot_decode_force_check is changed
+          - result_cannot_decode_force is changed
+          - value == 'Test'
+
+    # Text content
+
     - name: Create text file (check mode)
       community.sops.sops_encrypt:
         path: "{{ output_dir }}/test"
@@ -18,6 +68,9 @@
         path: "{{ output_dir }}/test"
         content_text: This is a text.
       register: result
+
+    - set_fact:
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test', rstrip=False) }}"
 
     - name: Create text file (idempotency, check mode)
       community.sops.sops_encrypt:
@@ -32,9 +85,37 @@
         content_text: This is a text.
       register: result_idempotent
 
+    - name: Create text file (change, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_text: |+
+          This is another text!
+
+          it has two newlines at the end.
+
+      check_mode: true
+      register: result_change_check
+
+    - name: Create text file (change)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_text: |+
+          This is another text!
+
+          it has two newlines at the end.
+
+      register: result_change
+
+    - set_fact:
+        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test', rstrip=false) }}"
+
     - assert:
         that:
           - result_check is changed
           - result is changed
+          - value_1 == 'This is a text.'
           - result_idempotent_check is not changed
           - result_idempotent is not changed
+          - result_change_check is changed
+          - result_change is changed
+          - value_2 == 'This is another text!\n\nit has two newlines at the end.\n\n'

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -119,3 +119,65 @@
           - result_change_check is changed
           - result_change is changed
           - value_2 == 'This is another text!\n\nit has two newlines at the end.\n\n'
+
+    # Binary content
+
+    - set_fact:
+        binary_value_1_b64: 'AQIDAAQ='
+        binary_value_2_b64: 'AQIDAAQgCg=='
+
+    - name: Create binary file (check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_binary: "{{ binary_value_1_b64 }}"
+      check_mode: true
+      register: result_check
+
+    - name: Create binary file
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_binary: "{{ binary_value_1_b64 }}"
+      register: result
+
+    - set_fact:
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test', base64=true, rstrip=False) }}"
+
+    - name: Create binary file (idempotency, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_binary: "{{ binary_value_1_b64 }}"
+      check_mode: true
+      register: result_idempotent_check
+
+    - name: Create binary file (idempotency)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_binary: "{{ binary_value_1_b64 }}"
+      register: result_idempotent
+
+    - name: Create binary file (change, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_binary: "{{ binary_value_2_b64 }}"
+      check_mode: true
+      register: result_change_check
+
+    - name: Create binary file (change)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_binary: "{{ binary_value_2_b64 }}"
+      register: result_change
+
+    - set_fact:
+        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test', base64=true, rstrip=false) }}"
+
+    - assert:
+        that:
+          - result_check is changed
+          - result is changed
+          - value_1 == binary_value_1_b64
+          - result_idempotent_check is not changed
+          - result_idempotent is not changed
+          - result_change_check is changed
+          - result_change is changed
+          - value_2 == binary_value_2_b64

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -1,0 +1,40 @@
+---
+- when: sops_installed
+  block:
+    - name: Place .sops.yaml
+      copy:
+        src: ".sops.yaml"
+        dest: "{{ output_dir }}/.sops.yaml"
+
+    - name: Create text file (check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_text: This is a text.
+      check_mode: true
+      register: result_check
+
+    - name: Create text file
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_text: This is a text.
+      register: result
+
+    - name: Create text file (idempotency, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_text: This is a text.
+      check_mode: true
+      register: result_idempotent_check
+
+    - name: Create text file (idempotency)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test"
+        content_text: This is a text.
+      register: result_idempotent
+
+    - assert:
+        that:
+          - result_check is changed
+          - result is changed
+          - result_idempotent_check is not changed
+          - result_idempotent is not changed

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -16,6 +16,18 @@
 
         binary_value_1_b64: 'AQIDAAQ='
         binary_value_2_b64: 'AQIDAAQgCg=='
+        json_value_1:
+          key1: value1
+          key2:
+            - value2.1
+            - value2.2
+        json_value_2:
+          key1: value1
+          key3:
+            - value3.1
+            - value3.2
+            - value3.3
+            - value3.4
 
     # Broken file overwrite
 
@@ -69,48 +81,48 @@
 
     - name: Create text file (check mode)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_text"
         content_text: "{{ text_value_1 }}"
       check_mode: true
       register: result_check
 
     - name: Create text file
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_text"
         content_text: "{{ text_value_1 }}"
       register: result
 
     - set_fact:
-        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test', rstrip=False) }}"
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_text', rstrip=False) }}"
 
     - name: Create text file (idempotency, check mode)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_text"
         content_text: "{{ text_value_1 }}"
       check_mode: true
       register: result_idempotent_check
 
     - name: Create text file (idempotency)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_text"
         content_text: "{{ text_value_1 }}"
       register: result_idempotent
 
     - name: Create text file (change, check mode)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_text"
         content_text: "{{ text_value_2 }}"
       check_mode: true
       register: result_change_check
 
     - name: Create text file (change)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_text"
         content_text: "{{ text_value_2 }}"
       register: result_change
 
     - set_fact:
-        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test', rstrip=false) }}"
+        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_text', rstrip=false) }}"
 
     - assert:
         that:
@@ -127,48 +139,48 @@
 
     - name: Create binary file (check mode)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_binary"
         content_binary: "{{ binary_value_1_b64 }}"
       check_mode: true
       register: result_check
 
     - name: Create binary file
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_binary"
         content_binary: "{{ binary_value_1_b64 }}"
       register: result
 
     - set_fact:
-        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test', base64=true, rstrip=False) }}"
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_binary', base64=true, rstrip=False) }}"
 
     - name: Create binary file (idempotency, check mode)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_binary"
         content_binary: "{{ binary_value_1_b64 }}"
       check_mode: true
       register: result_idempotent_check
 
     - name: Create binary file (idempotency)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_binary"
         content_binary: "{{ binary_value_1_b64 }}"
       register: result_idempotent
 
     - name: Create binary file (change, check mode)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_binary"
         content_binary: "{{ binary_value_2_b64 }}"
       check_mode: true
       register: result_change_check
 
     - name: Create binary file (change)
       community.sops.sops_encrypt:
-        path: "{{ output_dir }}/test"
+        path: "{{ output_dir }}/test_binary"
         content_binary: "{{ binary_value_2_b64 }}"
       register: result_change
 
     - set_fact:
-        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test', base64=true, rstrip=false) }}"
+        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_binary', base64=true, rstrip=false) }}"
 
     - assert:
         that:
@@ -180,3 +192,127 @@
           - result_change_check is changed
           - result_change is changed
           - value_2 == binary_value_2_b64
+
+    # JSON content
+
+    - name: Create JSON file (check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_json"
+        content_json: "{{ json_value_1 }}"
+      check_mode: true
+      register: result_check
+
+    - name: Create JSON file
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_json"
+        content_json: "{{ json_value_1 }}"
+      register: result
+
+    - set_fact:
+        value_1_raw: "{{ lookup('community.sops.sops', output_dir ~ '/test_json', base64=true) }}"
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_json') | from_json }}"
+
+    - name: Create JSON file (idempotency, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_json"
+        content_json: "{{ json_value_1 }}"
+      check_mode: true
+      register: result_idempotent_check
+
+    - name: Create JSON file (idempotency)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_json"
+        content_json: "{{ json_value_1 }}"
+      register: result_idempotent
+
+    - name: Create JSON file (change, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_json"
+        content_json: "{{ json_value_2 }}"
+      check_mode: true
+      register: result_change_check
+
+    - name: Create JSON file (change)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_json"
+        content_json: "{{ json_value_2 }}"
+      register: result_change
+
+    - set_fact:
+        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_json') | from_json }}"
+
+    - assert:
+        that:
+          - result_check is changed
+          - result is changed
+          - (value_1_raw | b64decode).startswith('{')
+          - value_1 == json_value_1
+          - result_idempotent_check is not changed
+          - result_idempotent is not changed
+          - result_change_check is changed
+          - result_change is changed
+          - value_2 == json_value_2
+
+    # YAML content
+
+    - name: Create YAML file (check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_yaml"
+        content_yaml: "{{ json_value_1 }}"
+      check_mode: true
+      register: result_check
+
+    - name: Create YAML file
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_yaml"
+        content_yaml: "{{ json_value_1 }}"
+      register: result
+
+    - set_fact:
+        value_1_raw: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml', base64=true) }}"
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml') | from_yaml }}"
+
+    - name: Create YAML file (idempotency, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_yaml"
+        content_yaml: "{{ json_value_1 }}"
+      check_mode: true
+      register: result_idempotent_check
+
+    - name: Create YAML file (idempotency)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_yaml"
+        content_yaml: "{{ json_value_1 }}"
+      register: result_idempotent
+
+    - name: Create YAML file (change, check mode)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_yaml"
+        content_yaml: "{{ json_value_2 }}"
+      check_mode: true
+      register: result_change_check
+
+    - name: Create YAML file (change)
+      community.sops.sops_encrypt:
+        path: "{{ output_dir }}/test_yaml"
+        content_yaml: "{{ json_value_2 }}"
+      register: result_change
+
+    - set_fact:
+        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml') | from_yaml }}"
+
+    - debug: var=value_1_raw
+    - debug: var=value_1
+    - debug: var=value_2
+
+    - assert:
+        that:
+          - result_check is changed
+          - result is changed
+          - not (value_1_raw | b64decode).startswith('{')
+          - value_1 == json_value_1
+          - result_idempotent_check is not changed
+          - result_idempotent is not changed
+          - result_change_check is changed
+          - result_change is changed
+          - value_2 == json_value_2

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -223,8 +223,8 @@
       register: result
 
     - set_fact:
-        value_1_raw: "{{ lookup('community.sops.sops', output_dir ~ '/test_json', base64=true) }}"
-        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_json') | from_json }}"
+        value_1_raw: "{{ lookup('community.sops.sops', output_dir ~ '/test_json', base64=true, output_type='json') }}"
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_json', output_type='json') | from_json }}"
 
     - name: Create JSON file (idempotency, check mode)
       community.sops.sops_encrypt:
@@ -253,7 +253,7 @@
       register: result_change
 
     - set_fact:
-        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_json') | from_json }}"
+        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_json', output_type='json') | from_json }}"
 
     - name: Place broken JSON file
       copy:
@@ -295,8 +295,8 @@
       register: result
 
     - set_fact:
-        value_1_raw: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml', base64=true) }}"
-        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml') | from_yaml }}"
+        value_1_raw: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml', base64=true, output_type='yaml') }}"
+        value_1: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml', output_type='yaml') | from_yaml }}"
 
     - name: Create YAML file (idempotency, check mode)
       community.sops.sops_encrypt:
@@ -325,7 +325,7 @@
       register: result_change
 
     - set_fact:
-        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml') | from_yaml }}"
+        value_2: "{{ lookup('community.sops.sops', output_dir ~ '/test_yaml', output_type='yaml') | from_yaml }}"
 
     - name: Place broken YAML file
       copy:
@@ -373,4 +373,5 @@
         that:
           - result_idem is not changed
           - value_1.data == text_value_1
-          - value_2.startswith('{')
+          - '"data" in value_2'
+          - value_2.data.startswith('ENC[')


### PR DESCRIPTION
This module allows to encrypt data (with idempotency). It accepts text data, binary data, JSON data or YAML data.

That allows to create roles or playbooks which encrypt data without having to fiddle with with sops calls yourself (which is non-trivial if you strive for idempotency, or don't want to write plaintext data to disk).
