### PR TITLE
Extend lookup plugin

### DIFF
--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -31,8 +31,12 @@ DOCUMENTATION = """
         - This lookup requires the C(sops) executable to be available in the controller PATH.
     options:
         _terms:
-            description: path(s) of files to read
-            required: True
+            description: Path(s) of files to read.
+            required: true
+        rstrip:
+            description: Whether to remove trailing newlines and spaces.
+            type: bool
+            default: true
     notes:
         - This lookup does not understand 'globbing' - use the fileglob lookup instead.
 """
@@ -74,6 +78,9 @@ display = Display()
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
+        self.set_options(direct=kwargs)
+        rstrip = self.get_option('rstrip')
+
         ret = []
 
         for term in terms:
@@ -85,10 +92,10 @@ class LookupModule(LookupBase):
                 raise AnsibleLookupError("could not locate file in lookup: %s" % to_native(term))
 
             try:
-                output = Sops.decrypt(lookupfile, display=display)
+                output = Sops.decrypt(lookupfile, display=display, rstrip=rstrip)
             except SopsError as e:
                 raise AnsibleLookupError(to_native(e))
 
-            ret.append(output.rstrip())
+            ret.append(output)
 
         return ret

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -37,6 +37,12 @@ DOCUMENTATION = """
             description: Whether to remove trailing newlines and spaces.
             type: bool
             default: true
+        base64:
+            description:
+                - Base64-encodes the parsed result.
+                - Use this if you want to store binary data in Ansible variables.
+            type: bool
+            default: false
     notes:
         - This lookup does not understand 'globbing' - use the fileglob lookup instead.
 """
@@ -66,6 +72,8 @@ RETURN = """
         elements: str
 """
 
+import base64
+
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_native
@@ -80,6 +88,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables=None, **kwargs):
         self.set_options(direct=kwargs)
         rstrip = self.get_option('rstrip')
+        use_base64 = self.get_option('base64')
 
         ret = []
 
@@ -92,9 +101,12 @@ class LookupModule(LookupBase):
                 raise AnsibleLookupError("could not locate file in lookup: %s" % to_native(term))
 
             try:
-                output = Sops.decrypt(lookupfile, display=display, rstrip=rstrip)
+                output = Sops.decrypt(lookupfile, display=display, rstrip=rstrip, decode_output=not use_base64)
             except SopsError as e:
                 raise AnsibleLookupError(to_native(e))
+
+            if use_base64:
+                output = to_native(base64.b64encode(output))
 
             ret.append(output)
 

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -57,16 +57,17 @@ class Sops():
     ''' Utility class to perform sops CLI actions '''
 
     @staticmethod
-    def decrypt(encrypted_file, display=None, rstrip=True):
+    def decrypt(encrypted_file, display=None, decode_output=True, rstrip=True):
         # Run sops directly, python module is deprecated
         command = ["sops", "--decrypt", encrypted_file]
         process = Popen(command, stdout=PIPE, stderr=PIPE)
         (output, err) = process.communicate()
         exit_code = process.returncode
 
-        # output is binary, we want UTF-8 string
-        output = to_text(output, errors='surrogate_or_strict')
-        # the process output is the decrypted secret; be cautious
+        if decode_output:
+            # output is binary, we want UTF-8 string
+            output = to_text(output, errors='surrogate_or_strict')
+            # the process output is the decrypted secret; be cautious
 
         # sops logs always to stderr, as stdout is used for
         # file content

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -57,7 +57,7 @@ class Sops():
     ''' Utility class to perform sops CLI actions '''
 
     @staticmethod
-    def decrypt(encrypted_file, display=None):
+    def decrypt(encrypted_file, display=None, rstrip=True):
         # Run sops directly, python module is deprecated
         command = ["sops", "--decrypt", encrypted_file]
         process = Popen(command, stdout=PIPE, stderr=PIPE)
@@ -76,4 +76,7 @@ class Sops():
         if exit_code > 0:
             raise SopsError(encrypted_file, exit_code, err)
 
-        return output.rstrip()
+        if rstrip:
+            output = output.rstrip()
+
+        return output

--- a/tests/integration/targets/lookup_sops/files/binary.sops
+++ b/tests/integration/targets/lookup_sops/files/binary.sops
@@ -1,0 +1,20 @@
+{
+	"data": "ENC[AES256_GCM,data:TrEN6YJBOg==,iv:aUozScYsBrM4khbqD2lMbGpEEXXO0Vy8YytBoG4HIf4=,tag:JlLZHqj2fsTi6v1rGeaxWw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-02T18:26:32Z",
+		"mac": "ENC[AES256_GCM,data:m4PPDNMYOPcDECiKJLF9Hg4jIInHj/xpj5bnGUkQxMm4XO2CDPal9g1FwTzwjOK9rXLUkdhWc8FuRh542EviVV8vOyUkjVAwN0x0bpXodBXB5r/9PPDwtObe/CUWnjo90Ow7IuX/BnQI6lf1sdPHf0MeTjGN9/l7tr6xg+92bIc=,iv:7q+TxZ65n2a+Vdb9KY6ISX92c1lEG2yTpa9KCt/QcUk=,tag:uR1AfcNd1dvH6LZy2oBDiw==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-02T18:26:31Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAR4QrVAJ5LhfX41457whWBdB74/O4OEZ76CkUGBvCVkGb\nHjJf9PAHFYH12UVnHEK3ZHKxKrVKPM2Pf3hsMGPuruS2wDuCWLteuMfQtlvCg1Xv\nLxiOfyEUEFc7Rl7uKmvni7XBeexIYN0DpxYa1Paz28ptQJCxZ84FK9y2jrFg2bUF\nq8R1JSTiY+YDXQBKSw3XgdJjjX2Yrpe85BV/l7pgREcwKEG4ZIU8n/zH2mgCObxp\nVfa50dAs5mfooU4g+xF34INhk7L+JPF0EBAbdrPyiw/7220dQSfCW0K3rgQkL1ZE\nB0wjH3S2anRO5t8E4S/YvXerq8LwtpCMczflLsCZ89LgAeStGGLFgZU53ASmq2dt\nqwQw4dCY4CngwuG/PuCt4nYV6VPgz+V+txpuq/aKQvcuFNhGsRtm4oP/vUlhqZQA\nivnqgO/DveCH5MxW9oMGLnYj4Jkbp0gRyALiqwNRz+HfSgA=\n=3dNe\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/lookup_sops/files/rstrip.sops
+++ b/tests/integration/targets/lookup_sops/files/rstrip.sops
@@ -1,0 +1,20 @@
+{
+	"data": "ENC[AES256_GCM,data:+x5Q1yGxpgvMQiwwMiCAiU0B5KA7i1eMvuRRxNLpKH0LEEs/7rpOInqKtA==,iv:96ihzWMxW45FqN28BCtX1emDBcXln9FN87Yf8bTlbbA=,tag:a8SiDQjFffOYHwKp5IhU2Q==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-02T18:14:42Z",
+		"mac": "ENC[AES256_GCM,data:CyLyYbG6rVwT8sRqLxLBuWUrgtUHz8XVwCx7iyiJDL925jzMvkA2ZEYxH6CsiWwc5/7tcFGLDSCjYw3AHD9x42LmsaAefk7F4X55++EI5VZbmSwyHdxCqvMVycKLJm3YXfodos8bbEWDDXhbmMT92uJs7H/IBXywnQHG3qoJWJE=,iv:ljY/d++R5v8VY5Q8nV0lnNwaeuEiKG4VTY8fSgFJD+w=,tag:MEtTIFuiSj8ReQOZNxO1IQ==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-02T18:11:54Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAblvrgBIPsg01TJjde7YskLvPKC/1jt1kI/eoOQ/KdemW\ngaJf4PIWGzFUxZEXeRzo70HTS+sPTi0TQDDkwOfcNjlGb3dC1KQdIZ1UiuqhL1//\n1G0doMMztEyZ63SOElv3OaWHjcnvmP224rTuFpO6Pm8HHMKEbaw9N7YHObgSdIpk\nfqEP369xj6bk/yQNEuMbgQOk+7LAYPs8na7oxIrdkWrmIlVj5jEz08lVS/FJecty\nUDalNDBkRrqMgTvSAw0vJTzaPzw/V+6WTrHh/0FRvLKJlKOsesaoxahW2/H1Dxmr\npySYTs2omqOtr3RzkCrUXmHijim9DIwg0JsIjo5xytLgAeSjSr9/W1EucekSGbeM\nmYK+4cN/4ILgRuH75OAw4qu0IgrgWuX6Eo7vO2HPrUiFLA/j+7/Bi+HkBZZuMrlR\njhd7C7MQGuD85NF3TzP2hW895ZiDznjWutHi69caRuEeZQA=\n=Aqvj\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -46,3 +46,13 @@
           - with_rstrip == 'This file has three newlines at the end.'
           - without_rstrip == 'This file has three newlines at the end.\n\n\n'
           - default_rstrip == 'This file has three newlines at the end.'
+
+    - name: Test binary
+      set_fact:
+        binary_with_rstrip: "{{ lookup('community.sops.sops', 'binary.sops', rstrip=true, base64=true) }}"
+        binary_without_rstrip: "{{ lookup('community.sops.sops', 'binary.sops', rstrip=false, base64=true) }}"
+
+    - assert:
+        that:
+          - binary_with_rstrip == 'AQIDAAQ='
+          - binary_without_rstrip == 'AQIDAAQgCg=='

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -34,3 +34,15 @@
         that:
           - "sops_lookup_simple is success"
           - "sops_success == 'foo: bar'"
+
+    - name: Test rstrip
+      set_fact:
+        with_rstrip: "{{ lookup('community.sops.sops', 'rstrip.sops', rstrip=true) }}"
+        without_rstrip: "{{ lookup('community.sops.sops', 'rstrip.sops', rstrip=false) }}"
+        default_rstrip: "{{ lookup('community.sops.sops', 'rstrip.sops') }}"
+
+    - assert:
+        that:
+          - with_rstrip == 'This file has three newlines at the end.'
+          - without_rstrip == 'This file has three newlines at the end.\n\n\n'
+          - default_rstrip == 'This file has three newlines at the end.'


### PR DESCRIPTION
### Motivation
Adds two options to the lookup plugin:
 - `rstrip` (type `bool`, default value `true`): whether to rstrip the result or not;
 - `base64` (type `bool`, default value `false`): whether to base64-encode the result and treat the sops output as binary data.

Right now I'm needing that for the tests for #23, but I think these are two additions which can be pretty useful.