### PR TITLE
load_vars: change 'static' option to 'expressions' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ tasks:
         file: path/to/sops-encrypted-file-with-jinja2-expressions.sops.yaml
         # The following allows to use Jinja2 expressions in the encrypted file!
         # They are evaluated right now, i.e. not later like when loaded with include_vars.
-        expressions: evaluate-now
+        expressions: evaluate-on-load
 ```
 
 ### encrypt_sops module

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ $ ansible-playbook playbooks/setup-server.yml -i inventory/hosts
 
 ### load_vars action plugin
 
-The `load_vars` action plugin can be used similarly to Ansible's `include_vars`, except that it right now only supports single files.
+The `load_vars` action plugin can be used similarly to Ansible's `include_vars`, except that it right now only supports single files. Also, it does not allow to load proper variables (i.e. "unsafe" Jinja2 expressions which evaluate on usage), but only facts. It does allow to evaluate expressions on load-time though.
 
 Examples:
 
@@ -121,14 +121,12 @@ tasks:
         file: path/to/sops-encrypted-file.sops.yaml
         name: variable_to_store_contents_in
 
-  - name: Load variables from file as proper variables into global namespace
+  - name: Load variables from file into global namespace, and evaluate Jinja2 expressions
     community.sops.load_vars:
         file: path/to/sops-encrypted-file-with-jinja2-expressions.sops.yaml
         # The following allows to use Jinja2 expressions in the encrypted file!
-        # They are evaluated when the corresponding variable is used. This allows
-        # expressions to reference other variables defined in the same file, and
-        # also variables/facts only defined later.
-        static: false
+        # They are evaluated right now, i.e. not later like when loaded with include_vars.
+        expressions: evaluate-now
 ```
 
 ### encrypt_sops module

--- a/plugins/action/load_vars.py
+++ b/plugins/action/load_vars.py
@@ -77,8 +77,8 @@ class ActionModule(ActionBase):
             if name is not None:
                 name = to_text(name)
             expressions = self._get_option('expressions', 'str', default='ignore')
-            if expressions not in ('ignore', 'evaluate-now'):
-                raise Exception('"expressions" must be one of "ignore" and "evaluate-now"')
+            if expressions not in ('ignore', 'evaluate-on-load'):
+                raise Exception('"expressions" must be one of "ignore" and "evaluate-on-load"')
         except Exception as e:
             result['failed'] = True
             result['message'] = to_text(e)
@@ -101,7 +101,7 @@ class ActionModule(ActionBase):
             value = dict()
             value[name] = data
 
-        if expressions == 'evaluate-now':
+        if expressions == 'evaluate-on-load':
             value = self._evaluate(value)
 
         result['ansible_included_var_files'] = files

--- a/plugins/action/load_vars.py
+++ b/plugins/action/load_vars.py
@@ -61,7 +61,7 @@ class ActionModule(ActionBase):
         if isinstance(value, Sequence):
             return [self._evaluate(v) for v in value]
         if isinstance(value, Mapping):
-            return {k: self._evaluate(v) for k, v in iteritems(value)}
+            return dict((k, self._evaluate(v)) for k, v in iteritems(value))
         return value
 
     def run(self, tmp=None, task_vars=None):

--- a/plugins/modules/load_vars.py
+++ b/plugins/modules/load_vars.py
@@ -28,18 +28,17 @@ options:
       - The name of a variable into which assign the included vars.
       - If omitted (C(null)) they will be made top level vars.
     type: str
-  static:
+  expressions:
     description:
-      - If set to C(false), the contents of the file will be loaded as real variables. This means that Jinja2 expressions
-        will be interpreted on usage of the variables.
-      - If set to the default value C(true), all strings will be interpreted as strings and will not be templated,
-        neither during loading nor during usage.
-      - Please note that C(false) is not officially supported by Ansible and is achieved by hacks. We try to make sure
-        that it works for all supported versions of Ansible.
-      - "NOTE: If set to C(false), DO NOT register the result of the task, or use this task for a loop!
-         This breaks the functionality somehow."
-    type: bool
-    default: true
+      - This option controls how Jinja2 expressions in values in the loaded file are handled.
+      - If set to C(ignore), expressions will not be evaluted, but treated as regular strings.
+      - If set to C(evaluate-now), expressions will be evaluated on execution of this module, i.e. now.
+      - Unfortunately, there is no way for non-core modules to handle expressions "unsafe", i.e. evaluate them only on use. This can only achieved by M(ansible.builtin.include_vars), which unfortunately cannot handle sops-encrypted files.
+    type: str
+    default: ignore
+    choices:
+        - ignore
+        - evaluate-now
 seealso:
 - module: ansible.builtin.set_fact
 - module: ansible.builtin.include_vars
@@ -52,13 +51,13 @@ EXAMPLES = r'''
   community.sops.load_vars:
     file: stuff.sops.yaml
     name: stuff
-    static: false  # interpret Jinja2 expressions in stuf.sops.yaml on usage of the vars!
+    expressions: evaluate-now  # interpret Jinja2 expressions in stuf.sops.yaml on load-time!
 
 - name: Conditionally decide to load in variables into 'plans' when x is 0, otherwise do not.
   community.sops.load_vars:
     file: contingency_plan.sops.yaml
     name: plans
-    static: true  # do not interpret possible Jinja2 expressions
+    expressions: ignore  # do not interpret possible Jinja2 expressions
   when: x == 0
 
 - name: Load variables into the global namespace

--- a/plugins/modules/load_vars.py
+++ b/plugins/modules/load_vars.py
@@ -33,7 +33,9 @@ options:
       - This option controls how Jinja2 expressions in values in the loaded file are handled.
       - If set to C(ignore), expressions will not be evaluted, but treated as regular strings.
       - If set to C(evaluate-now), expressions will be evaluated on execution of this module, i.e. now.
-      - Unfortunately, there is no way for non-core modules to handle expressions "unsafe", i.e. evaluate them only on use. This can only achieved by M(ansible.builtin.include_vars), which unfortunately cannot handle sops-encrypted files.
+      - Unfortunately, there is no way for non-core modules to handle expressions "unsafe",
+        i.e. evaluate them only on use. This can only achieved by M(ansible.builtin.include_vars),
+        which unfortunately cannot handle sops-encrypted files.
     type: str
     default: ignore
     choices:

--- a/plugins/modules/load_vars.py
+++ b/plugins/modules/load_vars.py
@@ -32,7 +32,8 @@ options:
     description:
       - This option controls how Jinja2 expressions in values in the loaded file are handled.
       - If set to C(ignore), expressions will not be evaluted, but treated as regular strings.
-      - If set to C(evaluate-now), expressions will be evaluated on execution of this module, i.e. now.
+      - If set to C(evaluate-on-load), expressions will be evaluated on execution of this module,
+        i.e. when the file is loaded.
       - Unfortunately, there is no way for non-core modules to handle expressions "unsafe",
         i.e. evaluate them only on use. This can only achieved by M(ansible.builtin.include_vars),
         which unfortunately cannot handle sops-encrypted files.
@@ -40,7 +41,7 @@ options:
     default: ignore
     choices:
         - ignore
-        - evaluate-now
+        - evaluate-on-load
 seealso:
 - module: ansible.builtin.set_fact
 - module: ansible.builtin.include_vars
@@ -53,7 +54,7 @@ EXAMPLES = r'''
   community.sops.load_vars:
     file: stuff.sops.yaml
     name: stuff
-    expressions: evaluate-now  # interpret Jinja2 expressions in stuf.sops.yaml on load-time!
+    expressions: evaluate-on-load  # interpret Jinja2 expressions in stuf.sops.yaml on load-time!
 
 - name: Conditionally decide to load in variables into 'plans' when x is 0, otherwise do not.
   community.sops.load_vars:

--- a/tests/integration/targets/load_vars/tasks/main.yml
+++ b/tests/integration/targets/load_vars/tasks/main.yml
@@ -80,40 +80,46 @@
           - "load_vars_simple_global.ansible_facts == {'foo': 'bar'}"
           - foo == 'bar'
 
-    - name: Test load_vars with proper vars file imported statically
+    - name: Test load_vars with expressions ignored
       community.sops.load_vars:
         file: proper-vars.sops.yaml
-        static: true
-      register: load_vars_vars_static
+        expressions: ignore
+      register: load_vars_expr_ignore
 
     - assert:
         that:
-          - load_vars_vars_static is success
+          - load_vars_expr_ignore is success
           - test1 == '{' ~ '{ bar }' ~ '}'
-          - test2 == '{' ~ '{ to_be_defined_later }' ~ '}'
+          - test2 == '{' ~ '{ this_will_not_get_evaluated }' ~ '}'
           - bar == 'baz'
 
-    - name: Test load_vars with proper vars file imported dynamically
+    - set_fact:
+        to_be_defined_earlier: something_defined_before
+        bar_2: baz
+
+    - name: Test load_vars with expressions evaluated now
       community.sops.load_vars:
         file: proper-vars-2.sops.yaml
-        static: false
-      # MUST NOT register the result, since it breaks variable registration.
-      # This also does not work for include_vars.
-      # (https://github.com/ansible/ansible/issues/71831)
+        expressions: evaluate-now
+      register: load_vars_expr_evaluated_now
 
     - set_fact:
-        to_be_defined_later: something_defined_later
+        to_be_defined_earlier: something_else
 
     - assert:
         that:
+          - load_vars_expr_evaluated_now is success
           - test1_2 == 'baz'
-          - test2_2 == 'something_defined_later'
+          - test2_2 == 'something_defined_before'
           - bar_2 == 'baz'
 
-    - name: Redefine to_be_defined_later
-      set_fact:
-        to_be_defined_later: something_defined_even_later
+    - name: Test load_vars with expressions evaluated now (again)
+      community.sops.load_vars:
+        file: proper-vars-2.sops.yaml
+        expressions: evaluate-now
+      register: load_vars_expr_evaluated_now_2
 
     - assert:
         that:
-          - test2_2 == 'something_defined_even_later'
+          - load_vars_expr_evaluated_now_2 is success
+          - test2_2 == 'something_else'

--- a/tests/integration/targets/load_vars/tasks/main.yml
+++ b/tests/integration/targets/load_vars/tasks/main.yml
@@ -112,7 +112,7 @@
     - name: Test load_vars with expressions evaluated now
       community.sops.load_vars:
         file: proper-vars-2.sops.yaml
-        expressions: evaluate-now
+        expressions: evaluate-on-load
       register: load_vars_expr_evaluated_now
 
     - set_fact:
@@ -129,7 +129,7 @@
     - name: Test load_vars with expressions evaluated now (again)
       community.sops.load_vars:
         file: proper-vars-2.sops.yaml
-        expressions: evaluate-now
+        expressions: evaluate-on-load
       register: load_vars_expr_evaluated_now_2
 
     - assert:

--- a/tests/integration/targets/load_vars/tasks/main.yml
+++ b/tests/integration/targets/load_vars/tasks/main.yml
@@ -23,6 +23,18 @@
           - load_vars_wrong_type is failed
           - '"is not a string and conversion is not allowed" in load_vars_wrong_type.message'
 
+    - name: Test load_vars with wrong choice value
+      community.sops.load_vars:
+        file: a
+        expressions: invalid value
+      ignore_errors: yes
+      register: load_vars_invalid_value
+
+    - assert:
+        that:
+          - load_vars_invalid_value is failed
+          - '"\"expressions\" must be one of " in load_vars_invalid_value.message'
+
     - name: Test load_vars with missing file
       community.sops.load_vars:
         file: non-existent.sops.yaml
@@ -111,7 +123,8 @@
           - load_vars_expr_evaluated_now is success
           - test1_2 == 'baz'
           - test2_2 == 'something_defined_before'
-          - bar_2 == 'baz'
+          - test3_2[0] == 'baz'
+          - test4_2.test_4_2_1 == 'bazbaz'
 
     - name: Test load_vars with expressions evaluated now (again)
       community.sops.load_vars:

--- a/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
@@ -1,15 +1,14 @@
 test1_2: ENC[AES256_GCM,data:iNGUgLK6RdJZQWA=,iv:FEx7YO17wTadHLcppnpElb5G5UIukfcHDatUkPzZ0rU=,tag:bKx9qwKiirzi7/lR0EQTEA==,type:str]
-test2_2: ENC[AES256_GCM,data:XuVX1GgPjLYmrQE4f3dcH59K5w2WAsXyhQ==,iv:JAAtajqwAjwG/LwEFISGnrO0fe+KKULFX5AhvL8/Hws=,tag:xOVpiXcMXe3PiCF4d/YZsQ==,type:str]
-bar_2: ENC[AES256_GCM,data:Uvwe,iv:uzyjGdPSki4QpGtwGKaqht7yPESNHojNq7vY3TGiqvc=,tag:FwG+9yFIkFWf/SItQ+NIZg==,type:str]
+test2_2: ENC[AES256_GCM,data:4rFASWUQQLqJgLnL3KAYIWpBoMGz38pTt4+w,iv:42avbhH4HzHhsCNdiPvZbowKbaWx76c+OYD8iZMELyk=,tag:9GSsbCYDQHX698S68cZe+g==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-09-20T20:29:19Z'
-    mac: ENC[AES256_GCM,data:GMDaz9qxuB9oVJsVrQrUuK8nb9IorwdUFvkHPeanysGWFIvPDylSXK3VLTTVJLFvcSWWaAfLrWXxEE+pPXSEO6z9jB0WQaTEdLQz9rWRYP7KHL6v+Eyid9OYd8xhqAZOJnFO/jesJhvmTAAM3u8dFqqnXw+5tfyTduIs7iPdOoQ=,iv:bF2ukC11B6Oo8MnYWUlWhGxFZ8JJEyeDZSkRi4PY3Tc=,tag:0GRYGtwjwIT9wogdXm2npA==,type:str]
+    lastmodified: '2020-10-07T18:46:33Z'
+    mac: ENC[AES256_GCM,data:CHdRPdXIoTPW+JQuK2tJ4f8tvI2LJ0lM6POGJ6XohN2/NcA8y2O2djA/Bqfvbwz/glgfHP+ylmnnISsNaqb7UIfgk7ErTIVwt1LpB3fKZbzYLBP5caD28CqaYk8nL5umP3MDYKR5c7VEwlgGhzkvhRPyHOUt60OlVJTFBXG030I=,iv:5G7RnCvzUsJt4Ep12v/ucgc8Cyr14eG4+NsDL5plUoc=,tag:FA+V05wibUeI5x9FIcL8QQ==,type:str]
     pgp:
-      - created_at: '2020-09-20T20:29:09Z'
+    -   created_at: '2020-09-20T20:29:09Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 

--- a/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
@@ -1,12 +1,17 @@
 test1_2: ENC[AES256_GCM,data:iNGUgLK6RdJZQWA=,iv:FEx7YO17wTadHLcppnpElb5G5UIukfcHDatUkPzZ0rU=,tag:bKx9qwKiirzi7/lR0EQTEA==,type:str]
 test2_2: ENC[AES256_GCM,data:4rFASWUQQLqJgLnL3KAYIWpBoMGz38pTt4+w,iv:42avbhH4HzHhsCNdiPvZbowKbaWx76c+OYD8iZMELyk=,tag:9GSsbCYDQHX698S68cZe+g==,type:str]
+test3_2:
+- ENC[AES256_GCM,data:nna0AD3fT6ySb7o=,iv:oX4yr3haXMCKvPNvbuzbnY1VeJQtT6svyij5IxkM8U4=,tag:T5C0b67m4Gu5OMFQLua7cw==,type:str]
+- ENC[AES256_GCM,data:iFsZo/M=,iv:Rt0S7vSQqT9eBt74/xLkUeRu91jLaroPs1oU707dqZ0=,tag:PHE2U6vUjOwc+vuERU5M8A==,type:int]
+test4_2:
+    test_4_2_1: ENC[AES256_GCM,data:PdqR2Sj2YI9YgWxrHd+iLszygZnzLA==,iv:rzY3GH7WH1E56vDirZ820R3oP7GTqjh1h/p0blTOBts=,tag:IDYNvBfTm2iklZVAI5Y4dw==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-10-07T18:46:33Z'
-    mac: ENC[AES256_GCM,data:CHdRPdXIoTPW+JQuK2tJ4f8tvI2LJ0lM6POGJ6XohN2/NcA8y2O2djA/Bqfvbwz/glgfHP+ylmnnISsNaqb7UIfgk7ErTIVwt1LpB3fKZbzYLBP5caD28CqaYk8nL5umP3MDYKR5c7VEwlgGhzkvhRPyHOUt60OlVJTFBXG030I=,iv:5G7RnCvzUsJt4Ep12v/ucgc8Cyr14eG4+NsDL5plUoc=,tag:FA+V05wibUeI5x9FIcL8QQ==,type:str]
+    lastmodified: '2020-10-07T19:09:46Z'
+    mac: ENC[AES256_GCM,data:ukYXQmbbOnausOseL6dcmBxZrPE5oHRirIebO8IUorFlas3NTUVFJCPJgJBA6cUa8KhFJDzfv2O+49y5h8j4Xu4w+3EuR42YukATVNbqLR1zQCO3N9fythqWWbxeiTlCXIK+Q+7FhC+UrY0FhFIKDc2iQOWdFYDSeBYg9vx1Spg=,iv:ksQOlDfvr4x25s+bbZywsRqVhvfbe2l81tBKzYVUBwI=,tag:mUD6aR6VbtCSF42dZwwnqg==,type:str]
     pgp:
       - created_at: '2020-09-20T20:29:09Z'
         enc: |-

--- a/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars-2.sops.yaml
@@ -8,7 +8,7 @@ sops:
     lastmodified: '2020-10-07T18:46:33Z'
     mac: ENC[AES256_GCM,data:CHdRPdXIoTPW+JQuK2tJ4f8tvI2LJ0lM6POGJ6XohN2/NcA8y2O2djA/Bqfvbwz/glgfHP+ylmnnISsNaqb7UIfgk7ErTIVwt1LpB3fKZbzYLBP5caD28CqaYk8nL5umP3MDYKR5c7VEwlgGhzkvhRPyHOUt60OlVJTFBXG030I=,iv:5G7RnCvzUsJt4Ep12v/ucgc8Cyr14eG4+NsDL5plUoc=,tag:FA+V05wibUeI5x9FIcL8QQ==,type:str]
     pgp:
-    -   created_at: '2020-09-20T20:29:09Z'
+      - created_at: '2020-09-20T20:29:09Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 

--- a/tests/integration/targets/load_vars/vars/proper-vars.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars.sops.yaml
@@ -9,7 +9,7 @@ sops:
     lastmodified: '2020-10-07T18:48:09Z'
     mac: ENC[AES256_GCM,data:u4+EQNjFXHsN2nF/WvXXoIkpFgAnagpH+NexBjicZbvAyrWuUgJxKQQxA6RtFdbvf1B3dT5PncPU+FyuUneN4/2ZMgcSGDl0HrA5+C3k7jKWwpk3lRBnkhPth+M4P51ThZ8mZRxRUKoRTivCip6/tL7NDqfCMPUmVG1NplRwhn4=,iv:k79E4eAU7EQLDi840VAPZXbFRmHKlx5HbAyJEBszztM=,tag:kknO0CvGVZaRFLB+plyctg==,type:str]
     pgp:
-    -   created_at: '2020-09-20T20:07:20Z'
+      - created_at: '2020-09-20T20:07:20Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 

--- a/tests/integration/targets/load_vars/vars/proper-vars.sops.yaml
+++ b/tests/integration/targets/load_vars/vars/proper-vars.sops.yaml
@@ -1,15 +1,15 @@
 test1: ENC[AES256_GCM,data:9Pqw99u2f3qG,iv:AhLP4qOm/OVA2GuRgAxARR8t5tdxjLxU5Cqjq2rSalU=,tag:6mKhNKuv7SQ43SiL1FcrPg==,type:str]
-test2: ENC[AES256_GCM,data:SS8y/zN8p6KctIk4KRfn3Q6nos5fsglewg==,iv:zSQm0reZ8d+0IQAGkCyb4VENtRcNN1MOW7Yu8fcHe2Y=,tag:5kl1ofM+Am50+opkoXBsvA==,type:str]
+test2: ENC[AES256_GCM,data:hDPhuyLcFDVddSf4V0bCc67AB6Je62EIYhLT3lr6wfL0,iv:RwY/Upk/es5Y5xzCkZawNDp8wjGkS/qzZo9ErKIwYbc=,tag:h73bPO+pYM08q9Wjx/6N2w==,type:str]
 bar: ENC[AES256_GCM,data:l4r5,iv:bxtHopVoSImLBY0u+1FUPe5qwJGk9nfy2ODI4vYhgiI=,tag:FjdNMkU0YFisswXbgEjCjA==,type:str]
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
-    lastmodified: '2020-09-20T20:07:56Z'
-    mac: ENC[AES256_GCM,data:AaweBPIMuppybdu2dOzQlFPB9+D0nwg3XBtHQ/Caffnk7IhTBkuIvG7FOYSOmsXGij+wDReunVAeIDdjrlF1jB7FulerQQQJ/Uvz188yVUiwrXUDqA8Vi1WJzpIU35w5JeukI5kyYSWrtTv8Rc5RIe37GgvZOoEicFQjh3mL9pE=,iv:yL9cWmS32YBurY2siO6mxI0cW93OZbBlHiemLByIsM4=,tag:p6muGvdSYtfz9LmVHt7Rtg==,type:str]
+    lastmodified: '2020-10-07T18:48:09Z'
+    mac: ENC[AES256_GCM,data:u4+EQNjFXHsN2nF/WvXXoIkpFgAnagpH+NexBjicZbvAyrWuUgJxKQQxA6RtFdbvf1B3dT5PncPU+FyuUneN4/2ZMgcSGDl0HrA5+C3k7jKWwpk3lRBnkhPth+M4P51ThZ8mZRxRUKoRTivCip6/tL7NDqfCMPUmVG1NplRwhn4=,iv:k79E4eAU7EQLDi840VAPZXbFRmHKlx5HbAyJEBszztM=,tag:kknO0CvGVZaRFLB+plyctg==,type:str]
     pgp:
-      - created_at: '2020-09-20T20:07:20Z'
+    -   created_at: '2020-09-20T20:07:20Z'
         enc: |-
             -----BEGIN PGP MESSAGE-----
 


### PR DESCRIPTION
Fixes #25 by removing the `static` option of `load_vars`. Instead, it adds a `expressions` option with values `ignore` and `evaluate-now`. If Ansible will ever allow action plugins to define proper variables, we can add a new option value `evaluate-on-use`, which would be a proper replacement for `static: false`. The value `evaluate-now` is a better-than-nothing replacement, which in some use-cases (like mine) is good enough.