### PR TITLE
Allow to tell sops lookup to return '' for non-existant files

### DIFF
--- a/changelogs/fragments/33-lookup-empty_on_not_exist.yml
+++ b/changelogs/fragments/33-lookup-empty_on_not_exist.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "sops lookup plugin - add ``empty_on_not_exist`` option which allows to return an empty string instead of an error when the file does not exist (https://github.com/ansible-collections/community.sops/pull/33)."

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -13,6 +13,16 @@
           - "sops_lookup_missing_file is failed"
           - "'could not locate file in lookup: file-does-not-exists.sops.yml' in sops_lookup_missing_file.msg"
 
+    - name: Test lookup with missing file with empty_on_not_exist
+      set_fact:
+        sops_file_does_not_exists_empty: "{{ lookup('community.sops.sops', 'file-does-not-exists.sops.yml', empty_on_not_exist=true) }}"
+      register: sops_lookup_missing_file_empty_on_not_exist
+
+    - assert:
+        that:
+          - "sops_lookup_missing_file_empty_on_not_exist is success"
+          - "sops_file_does_not_exists_empty == ''"
+
     - name: Test lookup of non-sops file
       set_fact:
         sops_wrong_file: "{{ lookup('community.sops.sops', 'wrong.yaml') }}"


### PR DESCRIPTION
### Motivation
This makes implementing things a lot easier. Instead of first having to do a stat to see if it really exists, one can simply specify `empty_on_not_exist=true` to the lookup and obtain an empty string instead of an error.

I'm using this in https://github.com/felixfontein/ansible-acme/ (I'm right now working on adding sops-encrypted keys support).