### PR TITLE
Declare minimal Ansible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ The following table shows which versions of sops were tested with which versions
 - latest 2.9 release
 - latest 2.10 release
 
+We minimally require Ansible 2.9.10. The vars plugin requires ansible-base 2.10 or later.
+
 ## External requirements
 
 <!-- List any external resources the collection depends on, for example minimum versions of an OS, libraries, or utilities. Do not list other Ansible collections here. -->

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,0 +1,2 @@
+---
+requires_ansible: '>=2.9.10'


### PR DESCRIPTION
### Motivation
To conform to the collection checklist, we need to declare a minimal supported Ansible version (https://github.com/ansible-collections/overview/blob/main/collection_requirements.rst#metaruntimeyml). I've picked 2.9.10, since this is the minimal version of 2.9 which got some deprecation-related things backported. Trying to do deprecations by code which are accepted by the sanity tests of Ansible 2.10 and 2.11 is only possible with 2.9.10 or later without crashing. We don't deprecate anything yet, but it's better to avoid having to bump the minimal Ansible version supported in case we ever need to deprecate something.

Also, Ansible 2.9 and 2.8 do not know about meta/runtime.yml, so one can still use the parts of the collection that work with it with older versions without any problems. It's just that I don't want to promise that it works ;)

@endorama what do you think?