### PR TITLE
Improve inventory tests, and improve staging docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ By default, the sops vars plugin caches decrypted files to avoid having to decry
 vars_cache = false
 ```
 
+Please note that when using vars plugin staging, this setting only has effect if the variables are not only loaded during the `inventory` stage. See the documentation of the `community.sops.sops` vars plugin for more details.
+
 ### load_vars action plugin
 
 The `load_vars` action plugin can be used similarly to Ansible's `include_vars`, except that it right now only supports single files. Also, it does not allow to load proper variables (i.e. "unsafe" Jinja2 expressions which evaluate on usage), but only facts. It does allow to evaluate expressions on load-time though.

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -51,6 +51,9 @@ DOCUMENTATION = '''
           - If the cache is disabled, the files will be decrypted for almost every task. This is very slow!
           - Only disable caching if you modify the variable files during a playbook run and want the updated
             result to be available from the next task on.
+          - "Note that setting I(stage) to C(inventory) has the same effect as setting I(cache) to C(true):
+             the variables will be loaded only once (during inventory loading) and the vars plugin will not
+             be called for every task."
         type: bool
         default: true
         version_added: 0.2.0

--- a/tests/integration/targets/var_sops/runme.sh
+++ b/tests/integration/targets/var_sops/runme.sh
@@ -25,7 +25,7 @@ for TEST in $(find . -maxdepth 1 -type d -name 'test-*' | sort); do
             ANSIBLE_VARS_ENABLED=host_group_vars,community.sops.sops ./run.sh "$@" 2>&1 | tee out
             RESULT=${PIPESTATUS[0]}
         else
-            ANSIBLE_VARS_ENABLED=host_group_vars,community.sops.sops ansible-playbook playbook.yml -v "$@" 2>&1 | tee out
+            ANSIBLE_VARS_ENABLED=host_group_vars,community.sops.sops ansible-playbook playbook.yml -i hosts -v "$@" 2>&1 | tee out
             RESULT=${PIPESTATUS[0]}
         fi
         ./validate.sh "${RESULT}" out

--- a/tests/integration/targets/var_sops/test-bad-file/hosts
+++ b/tests/integration/targets/var_sops/test-bad-file/hosts
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/tests/integration/targets/var_sops/test-bad-file/hosts
+++ b/tests/integration/targets/var_sops/test-bad-file/hosts
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/tests/integration/targets/var_sops/test-not-dir/hosts
+++ b/tests/integration/targets/var_sops/test-not-dir/hosts
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/tests/integration/targets/var_sops/test-not-dir/hosts
+++ b/tests/integration/targets/var_sops/test-not-dir/hosts
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/tests/integration/targets/var_sops/test-stage-inv-cache/.gitignore
+++ b/tests/integration/targets/var_sops/test-stage-inv-cache/.gitignore
@@ -1,0 +1,1 @@
+group_vars/

--- a/tests/integration/targets/var_sops/test-stage-inv-cache/hosts
+++ b/tests/integration/targets/var_sops/test-stage-inv-cache/hosts
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/tests/integration/targets/var_sops/test-stage-inv-cache/hosts
+++ b/tests/integration/targets/var_sops/test-stage-inv-cache/hosts
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/tests/integration/targets/var_sops/test-stage-inv-cache/playbook.yml
+++ b/tests/integration/targets/var_sops/test-stage-inv-cache/playbook.yml
@@ -2,10 +2,10 @@
 - hosts: localhost
   gather_facts: false
   tasks:
-    - name: Make sure group_vars/all.sops.yaml was not loaded
+    - name: Make sure group_vars/all.sops.yaml was loaded
       assert:
         that:
-          - foo is not defined
+          - foo is defined
           - bar is not defined
     - name: Replace group_vars/all.sops.yaml
       copy:
@@ -14,5 +14,5 @@
     - name: Make sure that updated group_vars/all.sops.yaml was not loaded
       assert:
         that:
-          - foo is not defined
+          - foo is defined
           - bar is not defined

--- a/tests/integration/targets/var_sops/test-stage-inv-cache/run.sh
+++ b/tests/integration/targets/var_sops/test-stage-inv-cache/run.sh
@@ -2,4 +2,4 @@
 set -e
 ANSIBLE_VARS_SOPS_PLUGIN_STAGE=inventory \
 ANSIBLE_VARS_SOPS_PLUGIN_CACHE=true \
-ansible-playbook playbook.yml -v "$@"
+ansible-playbook playbook.yml -i hosts -v "$@"

--- a/tests/integration/targets/var_sops/test-stage-inv-no-cache/.gitignore
+++ b/tests/integration/targets/var_sops/test-stage-inv-no-cache/.gitignore
@@ -1,0 +1,1 @@
+group_vars/

--- a/tests/integration/targets/var_sops/test-stage-inv-no-cache/hosts
+++ b/tests/integration/targets/var_sops/test-stage-inv-no-cache/hosts
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/tests/integration/targets/var_sops/test-stage-inv-no-cache/hosts
+++ b/tests/integration/targets/var_sops/test-stage-inv-no-cache/hosts
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/tests/integration/targets/var_sops/test-stage-inv-no-cache/playbook.yml
+++ b/tests/integration/targets/var_sops/test-stage-inv-no-cache/playbook.yml
@@ -2,10 +2,10 @@
 - hosts: localhost
   gather_facts: false
   tasks:
-    - name: Make sure group_vars/all.sops.yaml was not loaded
+    - name: Make sure group_vars/all.sops.yaml was loaded
       assert:
         that:
-          - foo is not defined
+          - foo is defined
           - bar is not defined
     - name: Replace group_vars/all.sops.yaml
       copy:
@@ -14,5 +14,5 @@
     - name: Make sure that updated group_vars/all.sops.yaml was not loaded
       assert:
         that:
-          - foo is not defined
+          - foo is defined
           - bar is not defined

--- a/tests/integration/targets/var_sops/test-stage-inv-no-cache/run.sh
+++ b/tests/integration/targets/var_sops/test-stage-inv-no-cache/run.sh
@@ -2,4 +2,4 @@
 set -e
 ANSIBLE_VARS_SOPS_PLUGIN_STAGE=inventory \
 ANSIBLE_VARS_SOPS_PLUGIN_CACHE=false \
-ansible-playbook playbook.yml -v "$@"
+ansible-playbook playbook.yml -i hosts -v "$@"

--- a/tests/integration/targets/var_sops/test-stage-task-cache/.gitignore
+++ b/tests/integration/targets/var_sops/test-stage-task-cache/.gitignore
@@ -1,0 +1,1 @@
+group_vars/

--- a/tests/integration/targets/var_sops/test-stage-task-cache/hosts
+++ b/tests/integration/targets/var_sops/test-stage-task-cache/hosts
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/tests/integration/targets/var_sops/test-stage-task-cache/hosts
+++ b/tests/integration/targets/var_sops/test-stage-task-cache/hosts
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/tests/integration/targets/var_sops/test-stage-task-cache/run.sh
+++ b/tests/integration/targets/var_sops/test-stage-task-cache/run.sh
@@ -2,4 +2,4 @@
 set -e
 ANSIBLE_VARS_SOPS_PLUGIN_STAGE=task \
 ANSIBLE_VARS_SOPS_PLUGIN_CACHE=true \
-ansible-playbook playbook.yml -v "$@"
+ansible-playbook playbook.yml -i hosts -v "$@"

--- a/tests/integration/targets/var_sops/test-stage-task-no-cache/.gitignore
+++ b/tests/integration/targets/var_sops/test-stage-task-no-cache/.gitignore
@@ -1,0 +1,1 @@
+group_vars/

--- a/tests/integration/targets/var_sops/test-stage-task-no-cache/hosts
+++ b/tests/integration/targets/var_sops/test-stage-task-no-cache/hosts
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/tests/integration/targets/var_sops/test-stage-task-no-cache/hosts
+++ b/tests/integration/targets/var_sops/test-stage-task-no-cache/hosts
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/tests/integration/targets/var_sops/test-stage-task-no-cache/run.sh
+++ b/tests/integration/targets/var_sops/test-stage-task-no-cache/run.sh
@@ -2,4 +2,4 @@
 set -e
 ANSIBLE_VARS_SOPS_PLUGIN_STAGE=task \
 ANSIBLE_VARS_SOPS_PLUGIN_CACHE=false \
-ansible-playbook playbook.yml -v "$@"
+ansible-playbook playbook.yml -i hosts -v "$@"

--- a/tests/integration/targets/var_sops/test-success/hosts
+++ b/tests/integration/targets/var_sops/test-success/hosts
@@ -1,0 +1,2 @@
+[all]
+localhost ansible_connection=local

--- a/tests/integration/targets/var_sops/test-success/hosts
+++ b/tests/integration/targets/var_sops/test-success/hosts
@@ -1,2 +1,2 @@
 [all]
-localhost ansible_connection=local
+localhost ansible_connection=local ansible_python_interpreter="{{ ansible_playbook_python }}"


### PR DESCRIPTION
There is a bug in ansible: if `localhost` is only implicitly defined (i.e. you don't define it yourself in the inventory), then vars plugins don't work properly for it. Therefore I added inventories with explicit `localhost` entries for the vars plugin. This also changes the test outcomes. I also updated the docs.