### PR TITLE
Fix 1.0.1 release; release 1.0.2 for that

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,13 +5,29 @@ Community Sops Release Notes
 .. contents:: Topics
 
 
+v1.0.2
+======
+
+Release Summary
+---------------
+
+Fix of 1.0.1 release which had no changelog entry.
+
+v1.0.1
+======
+
+Release Summary
+---------------
+
+Re-release of 1.0.0 to counteract error during release.
+
 v1.0.0
 ======
 
 Release Summary
 ---------------
 
-First stable release. This release is expected to be included in Ansible 3.0.0.
+First stable release. This release is expected to be included in Ansible 2.11.
 
 Minor Changes
 -------------

--- a/changelogs/.plugin-cache.yaml
+++ b/changelogs/.plugin-cache.yaml
@@ -31,4 +31,4 @@ plugins:
       description: Loading sops-encrypted vars files
       name: sops
       version_added: 0.1.0
-version: 1.0.0
+version: 1.0.2

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -58,3 +58,7 @@ releases:
     - 1.0.0.yml
     - 47-sops-options.yml
     release_date: '2021-01-14'
+  1.0.1:
+    changes:
+      release_summary: Re-release of 1.0.0 to counteract error during release.
+    release_date: '2021-01-14'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -7,7 +7,7 @@ releases:
         This release includes multiple plugins: an `action` plugin, a `lookup` plugin
         and a `vars` plugin.
 
-'
+        '
     fragments:
     - 0.1.0.yml
     modules:
@@ -61,4 +61,10 @@ releases:
   1.0.1:
     changes:
       release_summary: Re-release of 1.0.0 to counteract error during release.
+    release_date: '2021-01-14'
+  1.0.2:
+    changes:
+      release_summary: Fix of 1.0.1 release which had no changelog entry.
+    fragments:
+    - 1.0.2.yml
     release_date: '2021-01-14'

--- a/changelogs/fragments/1.0.2.yml
+++ b/changelogs/fragments/1.0.2.yml
@@ -1,0 +1,1 @@
+release_summary: Fix of 1.0.1 release which had no changelog entry.

--- a/changelogs/fragments/1.0.2.yml
+++ b/changelogs/fragments/1.0.2.yml
@@ -1,1 +1,0 @@
-release_summary: Fix of 1.0.1 release which had no changelog entry.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: community
 name: sops
-version: 1.0.0
+version: 1.0.2
 readme: README.md
 authors:
   - Edoardo Tenani


### PR DESCRIPTION
There is no 1.0.0 release on Galaxy, but we announced one and have one in the changelog, and there is a 1.0.1 release on Galaxy which has no changelog. To fix this, this modifies the changelog to add 1.0.1, and releases this fix as 1.0.2 so the version on Galaxy has a correct changelog.