### PR TITLE
vars and lookup plugins: fix syntax in Ansible vars specification so options can actually provided with vars

### DIFF
--- a/changelogs/fragments/51-fix-vars-arguments.yml
+++ b/changelogs/fragments/51-fix-vars-arguments.yml
@@ -1,2 +1,3 @@
 bugfixes:
-- "sops lookup and vars plugins - fix wrong format of Ansible variables so that these are actually used (https://github.com/ansible-collections/community.sops/issues/51)."
+- "sops lookup plugins - fix wrong format of Ansible variables so that these are actually used (https://github.com/ansible-collections/community.sops/pull/51)."
+- "sops vars plugins - remove non-working Ansible variables (https://github.com/ansible-collections/community.sops/pull/51)."

--- a/changelogs/fragments/51-fix-vars-arguments.yml
+++ b/changelogs/fragments/51-fix-vars-arguments.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- "sops lookup and vars plugins - fix wrong format of Ansible variables so that these are actually used (https://github.com/ansible-collections/community.sops/issues/51)."

--- a/plugins/doc_fragments/sops.py
+++ b/plugins/doc_fragments/sops.py
@@ -69,29 +69,29 @@ options:
     ANSIBLE_VARIABLES = r'''
 options:
     sops_binary:
-        var:
-            - sops_binary
+        vars:
+            - name: sops_binary
     aws_profile:
-        var:
-            - sops_aws_profile
+        vars:
+            - name: sops_aws_profile
     aws_access_key_id:
-        var:
-            - sops_aws_access_key_id
+        vars:
+            - name: sops_aws_access_key_id
     aws_secret_access_key:
-        var:
-            - sops_aws_secret_access_key
+        vars:
+            - name: sops_aws_secret_access_key
     aws_session_token:
-        var:
-            - sops_session_token
+        vars:
+            - name: sops_session_token
     config_path:
-        var:
-            - sops_config_path
+        vars:
+            - name: sops_config_path
     enable_local_keyservice:
-        var:
-            - sops_enable_local_keyservice
+        vars:
+            - name: sops_enable_local_keyservice
     keyservice:
-        var:
-            - sops_keyservice
+        vars:
+            - name: sops_keyservice
 '''
 
     ENCRYPT_SPECIFIC = r'''

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -124,7 +124,7 @@ display = Display()
 class LookupModule(LookupBase):
 
     def run(self, terms, variables=None, **kwargs):
-        self.set_options(direct=kwargs)
+        self.set_options(var_options=variables, direct=kwargs)
         rstrip = self.get_option('rstrip')
         use_base64 = self.get_option('base64')
         input_type = self.get_option('input_type')

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -65,7 +65,6 @@ DOCUMENTATION = '''
     extends_documentation_fragment:
         - ansible.builtin.vars_plugin_staging
         - community.sops.sops
-        - community.sops.sops.ansible_variables
 '''
 
 import os

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -117,11 +117,55 @@
         test_str_binary_data: This is binary data.
         test_str_abcd: a is b, and c is d
 
-    - name: Test fake sops binary
+    - name: Test fake sops binary (lookup parameters)
       set_fact:
         fake_sops_output: "{{ lookup('community.sops.sops', 'simple.sops.yaml', sops_binary=role_path ~ '/files/fake-sops.sh', enable_local_keyservice=True, aws_access_key_id='xxx') }}"
         fake_sops_output_2: "{{ lookup('community.sops.sops', 'simple.sops.yaml', sops_binary=role_path ~ '/files/fake-sops-val.sh', config_path='/path/to/asdf', aws_secret_access_key='yyy') }}"
         fake_sops_output_3: "{{ lookup('community.sops.sops', 'simple.sops.yaml', sops_binary=role_path ~ '/files/fake-sops-rep.sh', keyservice=['a', 'b'], aws_session_token='zzz') }}"
+
+    - assert:
+        that:
+          - fake_sops_output == 'fake sops output'
+          - fake_sops_output_2 == 'fake sops output 2'
+          - fake_sops_output_3 == 'fake sops output 3'
+
+    - name: Work around Ansible bug for next test
+      # https://github.com/ansible/ansible/issues/73268
+      set_fact:
+        sops_binary: "{{ role_path }}/files/fake-sops.sh"
+    - name: Test fake sops binary (Ansible variables, 1/3)
+      set_fact:
+        fake_sops_output: "{{ lookup('community.sops.sops', 'simple.sops.yaml') }}"
+      vars:
+        # sops_binary: "{{ role_path }}/files/fake-sops.sh"
+        sops_enable_local_keyservice: true
+        sops_aws_access_key_id: xxx
+
+    - name: Work around Ansible bug for next test
+      # https://github.com/ansible/ansible/issues/73268
+      set_fact:
+        sops_binary: "{{ role_path }}/files/fake-sops-val.sh"
+    - name: Test fake sops binary (Ansible variables, 2/3)
+      set_fact:
+        fake_sops_output_2: "{{ lookup('community.sops.sops', 'simple.sops.yaml') }}"
+      vars:
+        # sops_binary: "{{ role_path }}/files/fake-sops-val.sh"
+        sops_config_path: /path/to/asdf
+        sops_aws_secret_access_key: yyy
+
+    - name: Work around Ansible bug for next test
+      # https://github.com/ansible/ansible/issues/73268
+      set_fact:
+        sops_binary: "{{ role_path }}/files/fake-sops-rep.sh"
+    - name: Test fake sops binary (Ansible variables, 3/3)
+      set_fact:
+        fake_sops_output_3: "{{ lookup('community.sops.sops', 'simple.sops.yaml') }}"
+      vars:
+        # sops_binary: "{{ role_path }}/files/fake-sops-rep.sh"
+        sops_keyservice:
+          - a
+          - b
+        sops_session_token: zzz
 
     - assert:
         that:


### PR DESCRIPTION
I used the wrong syntax in #47.