### PR TITLE
sops_encrypt: mark parameters containing secrets with no_log=True

### DIFF
--- a/changelogs/fragments/54-no_log-fixes.yml
+++ b/changelogs/fragments/54-no_log-fixes.yml
@@ -1,0 +1,2 @@
+security_fixes:
+- "sops_encrypt - mark the ``aws_secret_access_key`` and ``aws_session_token`` parameters as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.sops/pull/54).""

--- a/changelogs/fragments/54-no_log-fixes.yml
+++ b/changelogs/fragments/54-no_log-fixes.yml
@@ -1,2 +1,2 @@
 security_fixes:
-- "sops_encrypt - mark the ``aws_secret_access_key`` and ``aws_session_token`` parameters as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.sops/pull/54).""
+- "sops_encrypt - mark the ``aws_secret_access_key`` and ``aws_session_token`` parameters as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.sops/pull/54)."

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -223,9 +223,11 @@ def get_sops_argument_spec(add_encrypt_specific=False):
         },
         'aws_secret_access_key': {
             'type': 'str',
+            'no_log': True,
         },
         'aws_session_token': {
             'type': 'str',
+            'no_log': True,
         },
         'config_path': {
             'type': 'path',
@@ -279,6 +281,7 @@ def get_sops_argument_spec(add_encrypt_specific=False):
             },
             'shamir_secret_sharing_threshold': {
                 'type': 'int',
+                'no_log': False,
             },
         })
     return argument_spec


### PR DESCRIPTION
More fallout from ansible/ansible#73508.

We should release this as 1.0.4 ASAP.