### PR TITLE
Remove `ubuntu16.04` from containers used for testing

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -79,9 +79,12 @@ jobs:
           - stable-2.10
           - devel
         docker_container:
+          - ubuntu1604
           - ubuntu1804
           - ubuntu2004
         exclude:
+          - ansible: devel
+            docker_container: ubuntu1604
           # ubuntu2004 is only available with ansible-core 2.11+ / devel
           - ansible: stable-2.9
             docker_container: ubuntu2004

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -79,7 +79,6 @@ jobs:
           - stable-2.10
           - devel
         docker_container:
-          - ubuntu1604
           - ubuntu1804
           - ubuntu2004
         exclude:


### PR DESCRIPTION
### Motivation

As per https://github.com/ansible-collections/overview/issues/45#issuecomment-776930466 from 1st of March `ubuntu1604` will not be supported anymore as available testing container.


### Changes description

- Remove `ubuntu1604` from containers in the integration test matrix

### Additional notes
<!-- any note related to these changes, please add them here -->

To be merged before 1st March 2021