### PR TITLE
sops_encrypt: YAML output type towards .yaml paths

### DIFF
--- a/changelogs/fragments/56-sops_encrypt-yaml-output.yaml
+++ b/changelogs/fragments/56-sops_encrypt-yaml-output.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - sops_encrypt - Use output type ``yaml`` when path ends with ``.yaml``
+  - sops_encrypt - use output type ``yaml`` when path ends with ``.yaml`` (https://github.com/ansible-collections/community.sops/pull/56).

--- a/changelogs/fragments/56-sops_encrypt-yaml-output.yaml
+++ b/changelogs/fragments/56-sops_encrypt-yaml-output.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - sops_encrypt - Use output type ``yaml`` when path ends with ``.yaml``

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -206,6 +206,8 @@ def main():
             output_type = None
             if path.endswith('.json'):
                 output_type = 'json'
+            elif path.endswith('.yaml'):
+                output_type = 'yaml'
             data = Sops.encrypt(
                 data=input_data, cwd=directory, input_type=input_type, output_type=output_type,
                 get_option_value=get_option_value, module=module,


### PR DESCRIPTION
Signed-off-by: Christian Hernvall <c.hernvall@yubico.com>

### Motivation
Use output_type `yaml` for sops_encrypt towards YAML files (`*.yaml`).

### Changes description
See motivation.

### Additional notes
First contribution to an Ansible community project. Let me know if I've missed something!
