### PR TITLE
Use FQCNs for new module/plugin announcements in changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,11 +13,10 @@ Release Summary
 
 This release fixes a bug that prevented correct YAML file to be created when the output was ending in `.yaml`.
 
-
 Bugfixes
 --------
 
-- sops_encrypt - use output type ``yaml`` when path ends with ``.yaml`` (https://github.com/ansible-collections/community.sops/pull/56).
+- community.sops.sops_encrypt - use output type ``yaml`` when path ends with ``.yaml`` (https://github.com/ansible-collections/community.sops/pull/56).
 
 v1.0.4
 ======
@@ -25,12 +24,12 @@ v1.0.4
 Release Summary
 ---------------
 
-This is a security release, fixing a potential information leak in the ``sops_encrypt`` module.
+This is a security release, fixing a potential information leak in the ``community.sops.sops_encrypt`` module.
 
 Security Fixes
 --------------
 
-- sops_encrypt - mark the ``aws_secret_access_key`` and ``aws_session_token`` parameters as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.sops/pull/54).
+- community.sops.sops_encrypt - mark the ``aws_secret_access_key`` and ``aws_session_token`` parameters as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.sops/pull/54).
 
 v1.0.3
 ======
@@ -43,8 +42,8 @@ This release include some fixes to Ansible docs and required changes for inclusi
 Bugfixes
 --------
 
-- sops lookup plugins - fix wrong format of Ansible variables so that these are actually used (https://github.com/ansible-collections/community.sops/pull/51).
-- sops vars plugins - remove non-working Ansible variables (https://github.com/ansible-collections/community.sops/pull/51).
+- community.sops.sops lookup plugins - fix wrong format of Ansible variables so that these are actually used (https://github.com/ansible-collections/community.sops/pull/51).
+- community.sops.sops vars plugins - remove non-working Ansible variables (https://github.com/ansible-collections/community.sops/pull/51).
 
 v1.0.2
 ======
@@ -74,7 +73,7 @@ Minor Changes
 -------------
 
 - All plugins and modules: allow to pass generic sops options with new options ``config_path``, ``enable_local_keyservice``, ``keyservice``. Also allow to pass AWS parameters with options ``aws_profile``, ``aws_access_key_id``, ``aws_secret_access_key``, and ``aws_session_token`` (https://github.com/ansible-collections/community.sops/pull/47).
-- sops_encrypt - allow to pass encryption-specific options ``kms``, ``gcp_kms``, ``azure_kv``, ``hc_vault_transit``, ``pgp``, ``unencrypted_suffix``, ``encrypted_suffix``, ``unencrypted_regex``, ``encrypted_regex``, ``encryption_context``, and ``shamir_secret_sharing_threshold`` to sops (https://github.com/ansible-collections/community.sops/pull/47).
+- community.sops.sops_encrypt - allow to pass encryption-specific options ``kms``, ``gcp_kms``, ``azure_kv``, ``hc_vault_transit``, ``pgp``, ``unencrypted_suffix``, ``encrypted_suffix``, ``unencrypted_regex``, ``encrypted_regex``, ``encryption_context``, and ``shamir_secret_sharing_threshold`` to sops (https://github.com/ansible-collections/community.sops/pull/47).
 
 v0.2.0
 ======
@@ -87,9 +86,9 @@ This release adds features for the lookup and vars plugins.
 Minor Changes
 -------------
 
-- sops lookup plugin - add ``empty_on_not_exist`` option which allows to return an empty string instead of an error when the file does not exist (https://github.com/ansible-collections/community.sops/pull/33).
-- sops vars plugin - add option to control caching (https://github.com/ansible-collections/community.sops/pull/32).
-- sops vars plugin - add option to determine when vars are loaded (https://github.com/ansible-collections/community.sops/pull/32).
+- community.sops.sops lookup plugin - add ``empty_on_not_exist`` option which allows to return an empty string instead of an error when the file does not exist (https://github.com/ansible-collections/community.sops/pull/33).
+- community.sops.sops vars plugin - add option to control caching (https://github.com/ansible-collections/community.sops/pull/32).
+- community.sops.sops vars plugin - add option to determine when vars are loaded (https://github.com/ansible-collections/community.sops/pull/32).
 
 v0.1.0
 ======
@@ -99,7 +98,6 @@ Release Summary
 
 First release of the `community.sops` collection!
 This release includes multiple plugins: an `action` plugin, a `lookup` plugin and a `vars` plugin.
-
 
 New Plugins
 -----------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -107,15 +107,15 @@ New Plugins
 Lookup
 ~~~~~~
 
-- sops - Read sops encrypted file contents
+- community.sops.sops - Read sops encrypted file contents
 
 Vars
 ~~~~
 
-- sops - Loading sops-encrypted vars files
+- community.sops.sops - Loading sops-encrypted vars files
 
 New Modules
 -----------
 
-- load_vars - Load sops-encrypted variables from files, dynamically within a task
-- sops_encrypt - Encrypt data with sops
+- community.sops.load_vars - Load sops-encrypted variables from files, dynamically within a task
+- community.sops.sops_encrypt - Encrypt data with sops

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -5,9 +5,7 @@ releases:
       release_summary: 'First release of the `community.sops` collection!
 
         This release includes multiple plugins: an `action` plugin, a `lookup` plugin
-        and a `vars` plugin.
-
-'
+        and a `vars` plugin.'
     fragments:
     - 0.1.0.yml
     modules:
@@ -31,10 +29,10 @@ releases:
   0.2.0:
     changes:
       minor_changes:
-      - sops lookup plugin - add ``empty_on_not_exist`` option which allows to return
+      - community.sops.sops lookup plugin - add ``empty_on_not_exist`` option which allows to return
         an empty string instead of an error when the file does not exist (https://github.com/ansible-collections/community.sops/pull/33).
-      - sops vars plugin - add option to control caching (https://github.com/ansible-collections/community.sops/pull/32).
-      - sops vars plugin - add option to determine when vars are loaded (https://github.com/ansible-collections/community.sops/pull/32).
+      - community.sops.sops vars plugin - add option to control caching (https://github.com/ansible-collections/community.sops/pull/32).
+      - community.sops.sops vars plugin - add option to determine when vars are loaded (https://github.com/ansible-collections/community.sops/pull/32).
       release_summary: This release adds features for the lookup and vars plugins.
     fragments:
     - 0.2.0.yml
@@ -48,7 +46,7 @@ releases:
         ``config_path``, ``enable_local_keyservice``, ``keyservice``. Also allow to
         pass AWS parameters with options ``aws_profile``, ``aws_access_key_id``, ``aws_secret_access_key``,
         and ``aws_session_token`` (https://github.com/ansible-collections/community.sops/pull/47).'
-      - sops_encrypt - allow to pass encryption-specific options ``kms``, ``gcp_kms``,
+      - community.sops.sops_encrypt - allow to pass encryption-specific options ``kms``, ``gcp_kms``,
         ``azure_kv``, ``hc_vault_transit``, ``pgp``, ``unencrypted_suffix``, ``encrypted_suffix``,
         ``unencrypted_regex``, ``encrypted_regex``, ``encryption_context``, and ``shamir_secret_sharing_threshold``
         to sops (https://github.com/ansible-collections/community.sops/pull/47).
@@ -71,9 +69,9 @@ releases:
   1.0.3:
     changes:
       bugfixes:
-      - sops lookup plugins - fix wrong format of Ansible variables so that these
+      - community.sops.sops lookup plugins - fix wrong format of Ansible variables so that these
         are actually used (https://github.com/ansible-collections/community.sops/pull/51).
-      - sops vars plugins - remove non-working Ansible variables (https://github.com/ansible-collections/community.sops/pull/51).
+      - community.sops.sops vars plugins - remove non-working Ansible variables (https://github.com/ansible-collections/community.sops/pull/51).
       release_summary: This release include some fixes to Ansible docs and required
         changes for inclusion in Ansible.
     fragments:
@@ -83,9 +81,9 @@ releases:
   1.0.4:
     changes:
       release_summary: This is a security release, fixing a potential information
-        leak in the ``sops_encrypt`` module.
+        leak in the ``community.sops.sops_encrypt`` module.
       security_fixes:
-      - sops_encrypt - mark the ``aws_secret_access_key`` and ``aws_session_token``
+      - community.sops.sops_encrypt - mark the ``aws_secret_access_key`` and ``aws_session_token``
         parameters as ``no_log`` to avoid leakage of secrets (https://github.com/ansible-collections/community.sops/pull/54).
     fragments:
     - 1.0.4.yml
@@ -94,11 +92,9 @@ releases:
   1.0.5:
     changes:
       bugfixes:
-      - sops_encrypt - use output type ``yaml`` when path ends with ``.yaml`` (https://github.com/ansible-collections/community.sops/pull/56).
+      - community.sops.sops_encrypt - use output type ``yaml`` when path ends with ``.yaml`` (https://github.com/ansible-collections/community.sops/pull/56).
       release_summary: 'This release fixes a bug that prevented correct YAML file
-        to be created when the output was ending in `.yaml`.
-
-'
+        to be created when the output was ending in `.yaml`.'
     fragments:
     - 1.0.5.yml
     - 56-sops_encrypt-yaml-output.yaml

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -27,3 +27,4 @@ sections:
   - Known Issues
 title: Community Sops
 trivial_section_name: trivial
+use_fqcn: true


### PR DESCRIPTION
Since all content cannot be used without FQCNs (or the dreaded `collections:` keyword in case of actions/modules), I think we should use them in the changelog as well. This PR modifies the changelog config so that auto-generated entries (new modules/plugins/...) automatically use FQCN.

@endorama what do you think? Should we also update other existing entries to use FQCN, like `community.sops.sops vars plugins - remove non-working Ansible variables` instead of `sops vars plugins - remove non-working Ansible variables` (https://github.com/ansible-collections/community.sops/blob/main/CHANGELOG.rst#bugfixes)?