### PR TITLE
ansible/ansible's stable-2.11 branch has been created.

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -17,6 +17,7 @@ jobs:
           # Testing against `devel` may fail as new tests are added.
           - stable-2.9
           - stable-2.10
+          - stable-2.11
           - devel
     runs-on: ubuntu-latest
     steps:
@@ -77,6 +78,7 @@ jobs:
           # Testing against `devel` may fail as new tests are added.
           - stable-2.9
           - stable-2.10
+          - stable-2.11
           - devel
         docker_container:
           - ubuntu1604
@@ -88,6 +90,8 @@ jobs:
           - 3.7.0
         exclude:
           - ansible: devel
+            docker_container: ubuntu1604
+          - ansible: stable-2.11
             docker_container: ubuntu1604
           # ubuntu2004 is only available with ansible-core 2.11+ / devel
           - ansible: stable-2.9

--- a/README.md
+++ b/README.md
@@ -18,13 +18,9 @@ The following table shows which versions of sops were tested with which versions
 
 ## Tested with Ansible
 
-<!-- List the versions of Ansible the collection has been tested with. Must match what is in galaxy.yml. -->
+Tested with the current Ansible 2.9, ansible-base 2.10 and ansible-core 2.11 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
-- `devel`
-- latest Ansible 2.9 release
-- latest ansible-base 2.10 release
-
-We minimally require Ansible 2.9.10. The vars plugin requires ansible-base 2.10 or later.
+The vars plugin requires ansible-base 2.10 or later.
 
 ## External requirements
 

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,0 +1,2 @@
+tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error
+tests/integration/targets/lookup_sops/files/hidden-json.yaml yamllint:error


### PR DESCRIPTION
##### SUMMARY
Makes the necessary adjustments to CI.

When stable-2.11 is actually branched:
1. Rebase
2. `cp tests/sanity/ignore-2.11.txt tests/sanity/ignore-2.12.txt ; git add tests/sanity/ignore-2.12.txt ; git commit --amend ; git push -f`

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
