### PR TITLE
Add inventory plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ To use it add the following to your `ansible.cfg`.
 enable_plugins = community.sops.sops
 ```
 
-create and inventory file with the extension `.sops.yaml` e.g.: `production.sops.yaml`.
+Encrypt an inventory file with sops with the extension `.sops.yaml`, for example encrypt `production.yaml` to `production.sops.yaml`.
 To test if it worked you can run `ansible-inventory -i production.sops.yaml`
 
 ## Troubleshooting

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Community Sops Collection
+
 [![CI](https://github.com/ansible-collections/community.sops/workflows/CI/badge.svg?event=push)](https://github.com/ansible-collections/community.sops/actions) [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.sops)](https://codecov.io/gh/ansible-collections/community.sops)
 
 <!-- Describe the collection and why a user would want to use it. What does the collection do? -->
+
 The `community.sops` collection allows integrating [`mozilla/sops`](https://github.com/mozilla/sops) in Ansible.
 
 `mozilla/sops` is a tool for encryption and decryption of files using secure keys (GPG, KMS). It can be leveraged in Ansible to provide an easy to use and flexible to manage way to manage ecrypted secrets' files.
@@ -10,11 +12,11 @@ The `community.sops` collection allows integrating [`mozilla/sops`](https://gith
 
 The following table shows which versions of sops were tested with which versions of the collection. Older (or newer) versions of sops can still work fine, it just means that we did not test them. In some cases, it could be that a minimal required version of sops is explicitly documented for a specific feature. Right now, that is not the case.
 
-|`community.sops` version|`mozilla/sops` version|
-|---|---|
-|0.1.0|`3.5.0+`|
-|1.0.6|`3.5.0+`|
-|`main` branch|`3.5.0`, `3.6.0`, `3.7.0`|
+| `community.sops` version | `mozilla/sops` version    |
+| ------------------------ | ------------------------- |
+| 0.1.0                    | `3.5.0+`                  |
+| 1.0.6                    | `3.5.0+`                  |
+| `main` branch            | `3.5.0`, `3.6.0`, `3.7.0` |
 
 ## Tested with Ansible
 
@@ -66,10 +68,9 @@ tasks:
 
 See [Lookup Plugins](https://docs.ansible.com/ansible/latest/plugins/lookup.html) for more details on lookup plugins
 
-
 ### vars plugin
 
-Vars plugins only work in ansible >= 2.10 and require explicit enabling.  One
+Vars plugins only work in ansible >= 2.10 and require explicit enabling. One
 way to enable the plugin is by adding the following to the `default` section of
 your `ansible.cfg`:
 
@@ -84,9 +85,9 @@ transparently decrypted with sops.
 
 The files must end with one of these extensions:
 
-* `.sops.yaml`
-* `.sops.yml`
-* `.sops.json`
+- `.sops.yaml`
+- `.sops.yml`
+- `.sops.json`
 
 Here is an example file structure
 
@@ -193,11 +194,25 @@ tasks:
                   key4: value5
 ```
 
+### inventory plugin
+
+In case you want to store secret keys like ansible_host, ansible_user, and others in your inventory you can use the inventory plugin.
+To use it add the following to your `ansible.cfg`.
+
+```ini
+[inventory]
+enable_plugins = community.sops.sops
+```
+
+create and inventory file with the extension `.sops.yaml` e.g.: `production.sops.yaml`.
+To test if it worked you can run `ansible-inventory -i production.sops.yaml`
+
 ## Troubleshooting
 
 ### Spurious failures during encryption and decryption with gpg
 
 Sops calls `gpg` with `--use-agent`. When running multiple of these in parallel, for example when loading variables or looking up files for various hosts at once, some of these can randomly fail with messages such as
+
 ```
 Failed to get the data key required to decrypt the SOPS file.
 
@@ -218,6 +233,7 @@ Recovery failed because no master key was able to decrypt the file. In
 order for SOPS to recover the file, at least one key has to be successful,
 but none were.
 ```
+
 This is a limitation of gpg-agent which can be fixed by adding `auto-expand-secmem` to `~/.gnupg/gpg-agent.conf` ([reference on option](https://www.gnupg.org/documentation/manuals/gnupg/Agent-Options.html#index-ssh_002dfingerprint_002ddigest), [reference on config file](https://www.gnupg.org/documentation/manuals/gnupg/Agent-Configuration.html)).
 
 (See https://github.com/ansible-collections/community.sops/issues/34 and https://dev.gnupg.org/T4146 for more details.)

--- a/plugins/inventory/sops.py
+++ b/plugins/inventory/sops.py
@@ -1,0 +1,56 @@
+import os
+from tempfile import NamedTemporaryFile
+
+from ansible.errors import AnsibleParserError
+from ansible.plugins.inventory import BaseInventoryPlugin
+from ansible.plugins.loader import inventory_loader
+
+
+from ansible_collections.community.sops.plugins.module_utils.sops import Sops
+
+
+class InventoryModule(BaseInventoryPlugin):
+
+    NAME = 'sops'
+    PATH_ENDINGS = (
+        '.sops.yml',
+        '.sops.yaml',
+        '.sops.json',
+    )
+
+    def verify_file(self, path):
+        if not any(path.endswith(ending) for ending in self.PATH_ENDINGS):
+            return False
+        return super(InventoryModule, self).verify_file(path)
+
+    def parse(self, inventory, loader, path, cache=True):
+        plugin_name = self._plugin_name_from_path(path)
+        plugin = inventory_loader.get(plugin_name)
+        if not plugin:
+            raise AnsibleParserError("sops requires the plugin {!r} to be enabled because of this file {!r}".format(plugin_name, path))
+        temporary = NamedTemporaryFile(mode='w', suffix=os.path.basename(path), delete=False)
+        with temporary as f:
+            f.write(Sops.decrypt(path))
+
+        try:
+            self._parse(plugin, inventory, loader, temporary.name, cache=cache)
+        finally:
+            os.unlink(temporary.name)
+
+    def _parse(self, plugin, inventory, loader, path, cache=True):
+        plugin.parse(inventory, loader, path, cache=cache)
+
+        try:
+            plugin.update_cache_if_changed()
+        except AttributeError:
+            pass
+
+    @staticmethod
+    def _plugin_name_from_path(path):
+        (_, extension) = os.path.splitext(path)
+        clean_extension = extension[1:]
+        extension_mapping = {
+            "yml": "yaml"
+        }
+        # If an invalid extension is sent, let the parser validate
+        return extension_mapping.get(clean_extension, clean_extension)

--- a/tests/integration/targets/inventory/.sops.yaml
+++ b/tests/integration/targets/inventory/.sops.yaml
@@ -1,0 +1,3 @@
+---
+creation_rules:
+    - pgp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4

--- a/tests/integration/targets/inventory/ansible.cfg
+++ b/tests/integration/targets/inventory/ansible.cfg
@@ -1,0 +1,2 @@
+[inventory]
+enable_plugins = community.sops.sops

--- a/tests/integration/targets/inventory/inventory.sops.yml
+++ b/tests/integration/targets/inventory/inventory.sops.yml
@@ -1,0 +1,30 @@
+all:
+    hosts:
+        encrypted_host:
+            ansible_host: ENC[AES256_GCM,data:tQMtCgI914beSVI=,iv:QWN+oU7neKwkNcObafrWd98f48vdXbDEImz9+805mN0=,tag:BRmjeh6nIKmNwuNDYCkJ7w==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2021-05-02T11:42:02Z"
+    mac: ENC[AES256_GCM,data:N6IcFfHRhkFZ4F005SBLaIBj/QnGzND0vNbT3HQvQD8rJA+OHKXG7Rj41+be/iyswxnkiMyHlXOFhjADkw/t4DIWQhNuOXZizkShoaat6qgkNaiuheF67zwKgtei2EsZ68pjMHt7k3/T6KYqNumD+0o99Tya+3ANl4VZGFivYZA=,iv:OZOfN7rYip3ANjv4udh75t0OqyKfedAbBPZeUh6w2jY=,tag:TaGcQExMDb7hDAqhN793Sg==,type:str]
+    pgp:
+        - created_at: "2021-05-02T11:03:14Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgArMcPLhc8CKOxnmmJgZ15XfDbp1SCEgMO+UbFmTZi8PaG
+            M370EfUkcH4Pivz9sr7S/ypeb8+vzcV1CtkjF6IQZsXqVlGwSTcB8C8mBMpFg87U
+            1pKxLGPBFv/zGiD47H6qoQV0zxVOezl+2FspslGWGSgUbNtmiqDCGa1MdwTs/lG1
+            idbGU5QdHbYoEn4o6n9xn2Efvyi9GtM2zpuyAwk9FUqb+vmLgdvtL1dmtNo2M6mK
+            YtY7kMBH9aVAtHeZON5fRNFKzoXixMLJ1WKiizAOE8Pp5t1KlL+PzAcykrLdvlzb
+            fOYBBSBaHQ7BLLKmxNfZxK4jMnNQ81ioFEpLN/YUqtLmATEf+cQmLWF1nbjEwM70
+            r6Etrb+1l2eQZtgftrvMSlyZAC2jt91B5+eCih9vBWd6sVtmCSkv7nRL6xwBHNqG
+            A+TxbajYv2xn2VBiOaD/Z0pc4hrTfLgA
+            =9XFP
+            -----END PGP MESSAGE-----
+          fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/tests/integration/targets/inventory/playbook.yml
+++ b/tests/integration/targets/inventory/playbook.yml
@@ -1,0 +1,19 @@
+- hosts: localhost
+  tasks:
+    - name: "test option: --list --export"
+      shell: ansible-inventory --list --export --inventory inventory.sops.yml
+      register: result
+
+    - assert:
+        that:
+            - result is succeeded
+            - '"my-host.com" in result.stdout'
+
+    - name: "test option: --host encrypted_host"
+      shell: ansible-inventory --inventory inventory.sops.yml --host encrypted_host
+      register: result
+
+    - assert:
+        that:
+            - result is succeeded
+            - '"my-host.com" in result.stdout'

--- a/tests/integration/targets/inventory/playbook.yml
+++ b/tests/integration/targets/inventory/playbook.yml
@@ -1,7 +1,7 @@
 - hosts: localhost
   tasks:
     - name: "test option: --list --export"
-      shell: ansible-inventory --list --export --inventory inventory.sops.yml
+      command: ansible-inventory --list --export --inventory inventory.sops.yml
       register: result
 
     - assert:
@@ -10,7 +10,7 @@
             - '"my-host.com" in result.stdout'
 
     - name: "test option: --host encrypted_host"
-      shell: ansible-inventory --inventory inventory.sops.yml --host encrypted_host
+      command: ansible-inventory --inventory inventory.sops.yml --host encrypted_host
       register: result
 
     - assert:

--- a/tests/integration/targets/inventory/runme.sh
+++ b/tests/integration/targets/inventory/runme.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ANSIBLE_CONFIG=ansible.cfg ansible-playbook -v playbook.yml


### PR DESCRIPTION
### Motivation
This allows you to encrypt inventories with sops

### Changes description
- Added an inventory plugin that decrypts the inventory and use the original module for the extension to deal with its data.
- Added a simple integration test to just check if decryption and integration with `ansible-inventory` works.

### Additional notes
<!-- any note related to these changes, please add them here -->
I am not sure on how to approach the documentation of the plugin as it leverages the yaml one to do the hard work.
I didn't add the ini support as sops goes nuts with ansible ini's implementation
