### PR TITLE
Add decrypt filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ tasks:
       - baz
 ```
 
-If you would use `{{ encrypted_data | community.sops.decrypt }}` instead of `{{ decrypted_data }}` in the debug task, the data would be decrypted three times for every host this is executed for. With the `ansible.builtin.set_fact` and `run_once: true`, it is evaluated only once.
+By using `{{ encrypted_data | community.sops.decrypt }}` instead of `{{ decrypted_data }}` in the debug task, the data would be decrypted three times for every host this is executed for. With the `ansible.builtin.set_fact` and `run_once: true`, it is evaluated only once.
 
 ### vars plugin
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ tasks:
       - baz
 ```
 
-By using `{{ encrypted_data | community.sops.decrypt }}` instead of `{{ decrypted_data }}` in the debug task, the data would be decrypted three times for every host this is executed for. With the `ansible.builtin.set_fact` and `run_once: true`, it is evaluated only once.
+By using `{{ encrypted_data | community.sops.decrypt }}` instead of `{{ decrypted_data }}` in the `openssl_privatekey` task, the data would be decrypted three times for every host this is executed for. With the `ansible.builtin.set_fact` and `run_once: true`, it is evaluated only once.
 
 ### vars plugin
 

--- a/README.md
+++ b/README.md
@@ -91,14 +91,16 @@ Please note that if you put a Jinja2 expression in a variable, it will be evalua
 
 ```yaml
 tasks:
-  - name: Decrypt data
+  - name: Decrypt data once
     ansible.builtin.set_fact:
       decrypted_data: "{{ encrypted_data | community.sops.decrypt }}"
     run_once: true  # if encrypted_data is identical on all hosts
 
-  - name: Output decrypted secrets multiple times (BAD IDEA!)
-    ansible.builtin.debug:
-      msg: "Decrypted data: {{ decrypted_data}}"
+  - name: Use decrypted secrets multiple times
+    ansible.builtin.openssl_privatekey:
+      path: "/path/to/private_{{ item }}.pem"
+      passphrase: "{{ decrypted_data }}"
+      cipher: auto
     loop:
       - foo
       - bar

--- a/changelogs/fragments/71-decrypt-filter.yml
+++ b/changelogs/fragments/71-decrypt-filter.yml
@@ -1,0 +1,3 @@
+add plugin.filter:
+  - name: decrypt
+    description: Decrypt sops-encrypted data

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -47,7 +47,7 @@ def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sop
             return enable_local_keyservice
         if argument_name == 'keyservice':
             return keyservice
-        return None
+        raise AssertionError('internal error: should not be reached')
 
     # Decode
     data = to_bytes(data)

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -24,10 +24,10 @@ def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sop
     # Check parameters
     if input_type not in _VALID_TYPES:
         raise AnsibleFilterError('input_type must be one of {expected}; got "{value}"'.format(
-            expected=', '.join(sorted(_VALID_TYPES)), got=input_type))
+            expected=', '.join(sorted(_VALID_TYPES)), value=input_type))
     if output_type not in _VALID_TYPES:
         raise AnsibleFilterError('output_type must be one of {expected}; got "{value}"'.format(
-            expected=', '.join(sorted(_VALID_TYPES)), got=output_type))
+            expected=', '.join(sorted(_VALID_TYPES)), value=output_type))
 
     # Create option value querier
     def get_option_value(argument_name):

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2021, Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.errors import AnsibleError, AnsibleFilterError
+from ansible.module_utils._text import to_bytes, to_native
+from ansible.utils.display import Display
+
+from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
+
+
+_VALID_TYPES = set(['binary', 'json', 'yaml', 'dotenv'])
+
+
+def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sops', rstrip=True, decode_output=True,
+                   aws_profile=None, aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None,
+                   config_path=None, enable_local_keyservice=None, keyservice=None):
+    '''Decrypt sops-encrypted data.'''
+
+    # Check parameters
+    if input_type not in _VALID_TYPES:
+        raise AnsibleFilterError('input_type must be one of {expected}; got "{value}"'.format(
+            expected=', '.join(sorted(_VALID_TYPES)), got=input_type))
+    if output_type not in _VALID_TYPES:
+        raise AnsibleFilterError('output_type must be one of {expected}; got "{value}"'.format(
+            expected=', '.join(sorted(_VALID_TYPES)), got=output_type))
+
+    # Create option value querier
+    def get_option_value(argument_name):
+        if argument_name == 'sops_binary':
+            return sops_binary
+        if argument_name == 'aws_profile':
+            return aws_profile
+        if argument_name == 'aws_access_key_id':
+            return aws_access_key_id
+        if argument_name == 'aws_secret_access_key':
+            return aws_secret_access_key
+        if argument_name == 'aws_session_token':
+            return aws_session_token
+        if argument_name == 'config_path':
+            return config_path
+        if argument_name == 'enable_local_keyservice':
+            return enable_local_keyservice
+        if argument_name == 'keyservice':
+            return keyservice
+        return None
+
+    # Decode
+    data = to_bytes(data)
+    try:
+        output = Sops.decrypt(
+            None, content=data, display=Display(), rstrip=rstrip, decode_output=decode_output,
+            input_type=input_type, output_type=output_type, get_option_value=get_option_value)
+    except SopsError as e:
+        raise AnsibleFilterError(to_native(e))
+
+    return output
+
+
+class FilterModule(object):
+    '''Ansible jinja2 filters'''
+
+    def filters(self):
+        return {
+            'decrypt': decrypt_filter,
+        }

--- a/tests/integration/targets/filter_decrypt/aliases
+++ b/tests/integration/targets/filter_decrypt/aliases
@@ -1,0 +1,5 @@
+shippable/posix/group1
+skip/aix
+skip/osx
+skip/freebsd
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter_decrypt/files/.sops.yaml
+++ b/tests/integration/targets/filter_decrypt/files/.sops.yaml
@@ -1,0 +1,3 @@
+---
+creation_rules:
+    - pgp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4

--- a/tests/integration/targets/filter_decrypt/files/binary.sops
+++ b/tests/integration/targets/filter_decrypt/files/binary.sops
@@ -1,0 +1,20 @@
+{
+	"data": "ENC[AES256_GCM,data:TrEN6YJBOg==,iv:aUozScYsBrM4khbqD2lMbGpEEXXO0Vy8YytBoG4HIf4=,tag:JlLZHqj2fsTi6v1rGeaxWw==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-02T18:26:32Z",
+		"mac": "ENC[AES256_GCM,data:m4PPDNMYOPcDECiKJLF9Hg4jIInHj/xpj5bnGUkQxMm4XO2CDPal9g1FwTzwjOK9rXLUkdhWc8FuRh542EviVV8vOyUkjVAwN0x0bpXodBXB5r/9PPDwtObe/CUWnjo90Ow7IuX/BnQI6lf1sdPHf0MeTjGN9/l7tr6xg+92bIc=,iv:7q+TxZ65n2a+Vdb9KY6ISX92c1lEG2yTpa9KCt/QcUk=,tag:uR1AfcNd1dvH6LZy2oBDiw==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-02T18:26:31Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAR4QrVAJ5LhfX41457whWBdB74/O4OEZ76CkUGBvCVkGb\nHjJf9PAHFYH12UVnHEK3ZHKxKrVKPM2Pf3hsMGPuruS2wDuCWLteuMfQtlvCg1Xv\nLxiOfyEUEFc7Rl7uKmvni7XBeexIYN0DpxYa1Paz28ptQJCxZ84FK9y2jrFg2bUF\nq8R1JSTiY+YDXQBKSw3XgdJjjX2Yrpe85BV/l7pgREcwKEG4ZIU8n/zH2mgCObxp\nVfa50dAs5mfooU4g+xF34INhk7L+JPF0EBAbdrPyiw/7220dQSfCW0K3rgQkL1ZE\nB0wjH3S2anRO5t8E4S/YvXerq8LwtpCMczflLsCZ89LgAeStGGLFgZU53ASmq2dt\nqwQw4dCY4CngwuG/PuCt4nYV6VPgz+V+txpuq/aKQvcuFNhGsRtm4oP/vUlhqZQA\nivnqgO/DveCH5MxW9oMGLnYj4Jkbp0gRyALiqwNRz+HfSgA=\n=3dNe\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/filter_decrypt/files/fake-sops-rep.sh
+++ b/tests/integration/targets/filter_decrypt/files/fake-sops-rep.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ "$1" != "--keyservice" ] || [ "$2" != "a" ] || [ "$3" != "--keyservice" ] || [ "$4" != "b" ] || [ "$5" != "--input-type" ] || [ "$6" != "yaml" ] || [ "$7" != "--output-type" ] || [ "$8" != "yaml" ] || [ "$9" != "--decrypt" ] || [ "${10}" != "/dev/stdin" ] || [ "${11}" != "" ]; then
+    echo "Command (fake-sops-rep): $*" > /dev/stderr
+    exit 1
+fi
+if [ "${AWS_SESSION_TOKEN}" != "zzz" ]; then
+    echo "AWS_SESSION_TOKEN is '${AWS_SESSION_TOKEN}'" > /dev/stderr
+    exit 1
+fi
+echo 'fake sops output 3'

--- a/tests/integration/targets/filter_decrypt/files/fake-sops-val.sh
+++ b/tests/integration/targets/filter_decrypt/files/fake-sops-val.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ "$1" != "--config" ] || [ "$2" != "/path/to/asdf" ] || [ "$3" != "--input-type" ] || [ "$4" != "yaml" ] || [ "$5" != "--output-type" ] || [ "$6" != "yaml" ] || [ "$7" != "--decrypt" ] || [ "$8" != "/dev/stdin" ] || [ "$9" != "" ]; then
+    echo "Command (fake-sops-val): $*" > /dev/stderr
+    exit 1
+fi
+if [ "${AWS_SECRET_ACCESS_KEY}" != "yyy" ]; then
+    echo "AWS_SECRET_ACCESS_KEY is '${AWS_SECRET_ACCESS_KEY}'" > /dev/stderr
+    exit 1
+fi
+echo 'fake sops output 2'

--- a/tests/integration/targets/filter_decrypt/files/fake-sops.sh
+++ b/tests/integration/targets/filter_decrypt/files/fake-sops.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+if [ "$1" != "--enable-local-keyservice" ] || [ "$2" != "--input-type" ] || [ "$3" != "yaml" ] || [ "$4" != "--output-type" ] || [ "$5" != "yaml" ] || [ "$6" != "--decrypt" ] || [ "$7" != "/dev/stdin" ] || [ "$8" != "" ]; then
+    echo "Command (fake-sops): $*" > /dev/stderr
+    exit 1
+fi
+if [ "${AWS_ACCESS_KEY_ID}" != "xxx" ]; then
+    echo "AWS_ACCESS_KEY_ID is '${AWS_ACCESS_KEY_ID}'" > /dev/stderr
+    exit 1
+fi
+echo 'fake sops output'

--- a/tests/integration/targets/filter_decrypt/files/hidden-binary
+++ b/tests/integration/targets/filter_decrypt/files/hidden-binary
@@ -1,0 +1,20 @@
+{
+	"data": "ENC[AES256_GCM,data:oJurKkZjXi4HVqV51shzRbl8,iv:OIg1gqchya6dMQtjYTMBeEfcddQLCtxL+ONnhR0jXEo=,tag:z0toZPLcUG3ZWB/tu59tqQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-07T20:21:46Z",
+		"mac": "ENC[AES256_GCM,data:fIH8AhiNyca43zDcKRFy5vkTHHY/OyWA1LXRCPRUJyHSFu8TQwJJ+7+5c7F/mI3P3exNjWv+sG53VAcxImqRsrd98QhllLJ6OjnVxpwKFTOjLJWfsvPEmoD+TpCnpuKxZSk303j2jCnIJ2cW0gOpPiUjm6LQ7JroMrBXKki71Ss=,iv:qM2PPktRKd7E5e1xmvmJzRaHnIOFk3dkaQ38Gg8idiw=,tag:ki7fs/rDf6vovyqBknVVHA==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-07T20:21:39Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAfr3xj1fG9yF91g+WMV1SG1dA+vR+nDkuGdNq3mn88660\nKiXOkEA8A6FrSpstKqsUb9Q6cotYiq3ld3dGPHve0AP9KzWvZEcogCpuk+CKaTnh\nimswI1Rr7jxZ9DecGn2koS07nGhNCXSdy2eAy0pDHpXbJnmb0CgHMXISeXiBZfs8\n19NtCMpcTbek4uR5jhazd0zSZWf1Gxls6pupBNaapwX0YyY+4cxc9O/spgDBd/R8\nrGNVOlA8svOnBQ8G0Ha+mn4p8ia7diSmPorRw1OGT9fJqnveVGsqk71rwem/5lv0\nEGSdXeYazjMP6Vlx0AaVBJFDNas9ozH3FMX2BRqWJNLgAeQE2dWrcbysQIi+QS6v\nfn3a4XYH4BzgcuHoQuAU4jqpMC3gv+UpiN+WK/Vc4Df/iMWQJB9uUm5iEbPRWwQx\n29a574BPbeBk5FxrDyMROm9YKb9GKa0F6WrimK5sdeF6VgA=\n=lJUR\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/filter_decrypt/files/hidden-binary-yaml
+++ b/tests/integration/targets/filter_decrypt/files/hidden-binary-yaml
@@ -1,0 +1,26 @@
+data: ENC[AES256_GCM,data:Mf66wk+/MdrPhiG3WMYkfTcs5Fdl,iv:r/CUJSou0b0w3pF7i3heDecV49jn82pTw2oQrMYModI=,tag:y342mhP4BfgsI5feBsJgoA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2020-10-07T20:25:54Z'
+    mac: ENC[AES256_GCM,data:srcP514/YUzHZErkByGupUKTF/QqfbzGkNC4Ojmyks5lHw0yWcz7T0GvuZEvXfrHAKUdBYjgaKvQnmed7CfBg5zlb8PL7Pg8b36WPM27EAJkAJzJG39xBov2u8l6sK7JcXMO31qIgzJDhPGsPfkk8yqs45EQC43DmYKU8dZkVaU=,iv:v8MeNADiPdl4fQPwfMSX12y3M0WoP7+9OXF4BWM8bkM=,tag:bXBIzoRtKydGp56fOTTctQ==,type:str]
+    pgp:
+    -   created_at: '2020-10-07T20:25:49Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgAb66JsAFfpWA1r11UevicTHKtZ6U8aT4wLlOWK9JilyTc
+            YlS0SfoU8v/CKbTlMndskCQOlhdK7b3LJG294/Gj6+v1bAz/yC9ivxmO/WeLupsl
+            XlcxrbMJcUASq0qsh4XYOhbNt1p47Ay5to8Ov+K/vPwA1a1QbsO5YbtMVrqQGNor
+            SoThRkVQ51yaxvIMStHXqPKuq4hdn4//pa+afThvbCCEopyc4SYbKXgNTX7+l7+N
+            r2LOKzDxg/koVN1HSpQ+kBDXiF4i4zSaBPBXN35Tv1y4vC0KUzdzVWiekMWksOqA
+            5ibGSLPhoOzIIz/Vda2t5o2LMeCaa36VXSbcXoL3i9LgAeQuZoNyyhrfwBOhARbi
+            ge7d4Q+o4ODgOOFSjeCr4msn9j3gCOX4+rKE2e9ZSFmSZzGv2vgWEo+h6qDxN29A
+            m2vhUzvrd+Br5DZRGB3LtEr3O4/lAN8DfwriyUDGKOEKRgA=
+            =4sXd
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/tests/integration/targets/filter_decrypt/files/hidden-binary-yaml.json
+++ b/tests/integration/targets/filter_decrypt/files/hidden-binary-yaml.json
@@ -1,0 +1,26 @@
+data: ENC[AES256_GCM,data:Mf66wk+/MdrPhiG3WMYkfTcs5Fdl,iv:r/CUJSou0b0w3pF7i3heDecV49jn82pTw2oQrMYModI=,tag:y342mhP4BfgsI5feBsJgoA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2020-10-07T20:25:54Z'
+    mac: ENC[AES256_GCM,data:srcP514/YUzHZErkByGupUKTF/QqfbzGkNC4Ojmyks5lHw0yWcz7T0GvuZEvXfrHAKUdBYjgaKvQnmed7CfBg5zlb8PL7Pg8b36WPM27EAJkAJzJG39xBov2u8l6sK7JcXMO31qIgzJDhPGsPfkk8yqs45EQC43DmYKU8dZkVaU=,iv:v8MeNADiPdl4fQPwfMSX12y3M0WoP7+9OXF4BWM8bkM=,tag:bXBIzoRtKydGp56fOTTctQ==,type:str]
+    pgp:
+    -   created_at: '2020-10-07T20:25:49Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgAb66JsAFfpWA1r11UevicTHKtZ6U8aT4wLlOWK9JilyTc
+            YlS0SfoU8v/CKbTlMndskCQOlhdK7b3LJG294/Gj6+v1bAz/yC9ivxmO/WeLupsl
+            XlcxrbMJcUASq0qsh4XYOhbNt1p47Ay5to8Ov+K/vPwA1a1QbsO5YbtMVrqQGNor
+            SoThRkVQ51yaxvIMStHXqPKuq4hdn4//pa+afThvbCCEopyc4SYbKXgNTX7+l7+N
+            r2LOKzDxg/koVN1HSpQ+kBDXiF4i4zSaBPBXN35Tv1y4vC0KUzdzVWiekMWksOqA
+            5ibGSLPhoOzIIz/Vda2t5o2LMeCaa36VXSbcXoL3i9LgAeQuZoNyyhrfwBOhARbi
+            ge7d4Q+o4ODgOOFSjeCr4msn9j3gCOX4+rKE2e9ZSFmSZzGv2vgWEo+h6qDxN29A
+            m2vhUzvrd+Br5DZRGB3LtEr3O4/lAN8DfwriyUDGKOEKRgA=
+            =4sXd
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/tests/integration/targets/filter_decrypt/files/hidden-binary-yaml.yaml
+++ b/tests/integration/targets/filter_decrypt/files/hidden-binary-yaml.yaml
@@ -1,0 +1,26 @@
+data: ENC[AES256_GCM,data:Mf66wk+/MdrPhiG3WMYkfTcs5Fdl,iv:r/CUJSou0b0w3pF7i3heDecV49jn82pTw2oQrMYModI=,tag:y342mhP4BfgsI5feBsJgoA==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2020-10-07T20:25:54Z'
+    mac: ENC[AES256_GCM,data:srcP514/YUzHZErkByGupUKTF/QqfbzGkNC4Ojmyks5lHw0yWcz7T0GvuZEvXfrHAKUdBYjgaKvQnmed7CfBg5zlb8PL7Pg8b36WPM27EAJkAJzJG39xBov2u8l6sK7JcXMO31qIgzJDhPGsPfkk8yqs45EQC43DmYKU8dZkVaU=,iv:v8MeNADiPdl4fQPwfMSX12y3M0WoP7+9OXF4BWM8bkM=,tag:bXBIzoRtKydGp56fOTTctQ==,type:str]
+    pgp:
+      - created_at: '2020-10-07T20:25:49Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgAb66JsAFfpWA1r11UevicTHKtZ6U8aT4wLlOWK9JilyTc
+            YlS0SfoU8v/CKbTlMndskCQOlhdK7b3LJG294/Gj6+v1bAz/yC9ivxmO/WeLupsl
+            XlcxrbMJcUASq0qsh4XYOhbNt1p47Ay5to8Ov+K/vPwA1a1QbsO5YbtMVrqQGNor
+            SoThRkVQ51yaxvIMStHXqPKuq4hdn4//pa+afThvbCCEopyc4SYbKXgNTX7+l7+N
+            r2LOKzDxg/koVN1HSpQ+kBDXiF4i4zSaBPBXN35Tv1y4vC0KUzdzVWiekMWksOqA
+            5ibGSLPhoOzIIz/Vda2t5o2LMeCaa36VXSbcXoL3i9LgAeQuZoNyyhrfwBOhARbi
+            ge7d4Q+o4ODgOOFSjeCr4msn9j3gCOX4+rKE2e9ZSFmSZzGv2vgWEo+h6qDxN29A
+            m2vhUzvrd+Br5DZRGB3LtEr3O4/lAN8DfwriyUDGKOEKRgA=
+            =4sXd
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/tests/integration/targets/filter_decrypt/files/hidden-binary.json
+++ b/tests/integration/targets/filter_decrypt/files/hidden-binary.json
@@ -1,0 +1,20 @@
+{
+	"data": "ENC[AES256_GCM,data:oJurKkZjXi4HVqV51shzRbl8,iv:OIg1gqchya6dMQtjYTMBeEfcddQLCtxL+ONnhR0jXEo=,tag:z0toZPLcUG3ZWB/tu59tqQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-07T20:21:46Z",
+		"mac": "ENC[AES256_GCM,data:fIH8AhiNyca43zDcKRFy5vkTHHY/OyWA1LXRCPRUJyHSFu8TQwJJ+7+5c7F/mI3P3exNjWv+sG53VAcxImqRsrd98QhllLJ6OjnVxpwKFTOjLJWfsvPEmoD+TpCnpuKxZSk303j2jCnIJ2cW0gOpPiUjm6LQ7JroMrBXKki71Ss=,iv:qM2PPktRKd7E5e1xmvmJzRaHnIOFk3dkaQ38Gg8idiw=,tag:ki7fs/rDf6vovyqBknVVHA==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-07T20:21:39Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAfr3xj1fG9yF91g+WMV1SG1dA+vR+nDkuGdNq3mn88660\nKiXOkEA8A6FrSpstKqsUb9Q6cotYiq3ld3dGPHve0AP9KzWvZEcogCpuk+CKaTnh\nimswI1Rr7jxZ9DecGn2koS07nGhNCXSdy2eAy0pDHpXbJnmb0CgHMXISeXiBZfs8\n19NtCMpcTbek4uR5jhazd0zSZWf1Gxls6pupBNaapwX0YyY+4cxc9O/spgDBd/R8\nrGNVOlA8svOnBQ8G0Ha+mn4p8ia7diSmPorRw1OGT9fJqnveVGsqk71rwem/5lv0\nEGSdXeYazjMP6Vlx0AaVBJFDNas9ozH3FMX2BRqWJNLgAeQE2dWrcbysQIi+QS6v\nfn3a4XYH4BzgcuHoQuAU4jqpMC3gv+UpiN+WK/Vc4Df/iMWQJB9uUm5iEbPRWwQx\n29a574BPbeBk5FxrDyMROm9YKb9GKa0F6WrimK5sdeF6VgA=\n=lJUR\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/filter_decrypt/files/hidden-binary.yaml
+++ b/tests/integration/targets/filter_decrypt/files/hidden-binary.yaml
@@ -1,0 +1,20 @@
+{
+	"data": "ENC[AES256_GCM,data:oJurKkZjXi4HVqV51shzRbl8,iv:OIg1gqchya6dMQtjYTMBeEfcddQLCtxL+ONnhR0jXEo=,tag:z0toZPLcUG3ZWB/tu59tqQ==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-07T20:21:46Z",
+		"mac": "ENC[AES256_GCM,data:fIH8AhiNyca43zDcKRFy5vkTHHY/OyWA1LXRCPRUJyHSFu8TQwJJ+7+5c7F/mI3P3exNjWv+sG53VAcxImqRsrd98QhllLJ6OjnVxpwKFTOjLJWfsvPEmoD+TpCnpuKxZSk303j2jCnIJ2cW0gOpPiUjm6LQ7JroMrBXKki71Ss=,iv:qM2PPktRKd7E5e1xmvmJzRaHnIOFk3dkaQ38Gg8idiw=,tag:ki7fs/rDf6vovyqBknVVHA==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-07T20:21:39Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAfr3xj1fG9yF91g+WMV1SG1dA+vR+nDkuGdNq3mn88660\nKiXOkEA8A6FrSpstKqsUb9Q6cotYiq3ld3dGPHve0AP9KzWvZEcogCpuk+CKaTnh\nimswI1Rr7jxZ9DecGn2koS07nGhNCXSdy2eAy0pDHpXbJnmb0CgHMXISeXiBZfs8\n19NtCMpcTbek4uR5jhazd0zSZWf1Gxls6pupBNaapwX0YyY+4cxc9O/spgDBd/R8\nrGNVOlA8svOnBQ8G0Ha+mn4p8ia7diSmPorRw1OGT9fJqnveVGsqk71rwem/5lv0\nEGSdXeYazjMP6Vlx0AaVBJFDNas9ozH3FMX2BRqWJNLgAeQE2dWrcbysQIi+QS6v\nfn3a4XYH4BzgcuHoQuAU4jqpMC3gv+UpiN+WK/Vc4Df/iMWQJB9uUm5iEbPRWwQx\n29a574BPbeBk5FxrDyMROm9YKb9GKa0F6WrimK5sdeF6VgA=\n=lJUR\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/filter_decrypt/files/hidden-json
+++ b/tests/integration/targets/filter_decrypt/files/hidden-json
@@ -1,0 +1,21 @@
+{
+	"a": "ENC[AES256_GCM,data:/Q==,iv:q+yypwZjX2frKGNruAFF+XSnmz+IU3AQ5XuUMWhhyhA=,tag:skm5wsq8a3/EESLVic8yKw==,type:str]",
+	"c": "ENC[AES256_GCM,data:DQ==,iv:JvvR1pXyp6L+i4keXDwLM79oxP6K1nqeGkIC5OgR38c=,tag:QbtjRLx47fN5M4+zaaQBVA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-07T20:21:33Z",
+		"mac": "ENC[AES256_GCM,data:rbWY/H6bj2UFpybJHqsS02wjy8VMvNvzQUtd6fBMSsvvv1fYWWoULO32LGA635spoFkVyOpX4hipqVyjRfQ1KyP1rNssggaHMz+nRUUFOmiQAcT9wi/Y0IKWjgN1cjI1stCU10b5cfJZQ0SPi/OFC8KcptMaHpfDVF47ZfnprFs=,iv:rVtp2Ti4xHNOWeS4MKju1jFZ/VyE7oXXdTSpp4jSU34=,tag:kd0IeyLXY598kdvSX0+1DA==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-07T20:21:18Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAPQ6Bn3MlvYUPs+e0njFUoq4AZAhR38BIWGAzTAMeWfIH\n0JZwol5f1leoyKX5Bmye1S+n72zZz3C4FxhSqh80boxNpHuVyeLrAkzv25AaAS8Q\n/9mSYquvJcIL7nWX/QmgTVTaXrqlxZSVva6Slwf7zlaLBqVJfv1RDwT6JEWDIJig\nJp35PKpwRe70IZDGAelcDtJicmjQrvfVhyb1/0kTTv4JdylixVnQdh9X/zw5ZSBG\nusEW/JG9nZ/xzKsEQpafCBLhP80jx3z37zKbsJ+4K2xsBTGQQdU5KdDSnosw/L/b\nHlOCwaMQgb/dQPA5fpwVyGnVas6GK7gQvzznHAiHc9LgAeT0brybsEaAPOuA94/V\nA/ny4cub4Mzg0eFWf+C94i6lS1/gtuWI2PEva3259aEycV6gpYSOoPh3tYlBoVlM\ntj01l2eYfeBn5MNIWuhqfGTL4mLuzfiYsvnigdvTsOEIwgA=\n=yKCo\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/filter_decrypt/files/hidden-json.json
+++ b/tests/integration/targets/filter_decrypt/files/hidden-json.json
@@ -1,0 +1,21 @@
+{
+	"a": "ENC[AES256_GCM,data:/Q==,iv:q+yypwZjX2frKGNruAFF+XSnmz+IU3AQ5XuUMWhhyhA=,tag:skm5wsq8a3/EESLVic8yKw==,type:str]",
+	"c": "ENC[AES256_GCM,data:DQ==,iv:JvvR1pXyp6L+i4keXDwLM79oxP6K1nqeGkIC5OgR38c=,tag:QbtjRLx47fN5M4+zaaQBVA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-07T20:21:33Z",
+		"mac": "ENC[AES256_GCM,data:rbWY/H6bj2UFpybJHqsS02wjy8VMvNvzQUtd6fBMSsvvv1fYWWoULO32LGA635spoFkVyOpX4hipqVyjRfQ1KyP1rNssggaHMz+nRUUFOmiQAcT9wi/Y0IKWjgN1cjI1stCU10b5cfJZQ0SPi/OFC8KcptMaHpfDVF47ZfnprFs=,iv:rVtp2Ti4xHNOWeS4MKju1jFZ/VyE7oXXdTSpp4jSU34=,tag:kd0IeyLXY598kdvSX0+1DA==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-07T20:21:18Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAPQ6Bn3MlvYUPs+e0njFUoq4AZAhR38BIWGAzTAMeWfIH\n0JZwol5f1leoyKX5Bmye1S+n72zZz3C4FxhSqh80boxNpHuVyeLrAkzv25AaAS8Q\n/9mSYquvJcIL7nWX/QmgTVTaXrqlxZSVva6Slwf7zlaLBqVJfv1RDwT6JEWDIJig\nJp35PKpwRe70IZDGAelcDtJicmjQrvfVhyb1/0kTTv4JdylixVnQdh9X/zw5ZSBG\nusEW/JG9nZ/xzKsEQpafCBLhP80jx3z37zKbsJ+4K2xsBTGQQdU5KdDSnosw/L/b\nHlOCwaMQgb/dQPA5fpwVyGnVas6GK7gQvzznHAiHc9LgAeT0brybsEaAPOuA94/V\nA/ny4cub4Mzg0eFWf+C94i6lS1/gtuWI2PEva3259aEycV6gpYSOoPh3tYlBoVlM\ntj01l2eYfeBn5MNIWuhqfGTL4mLuzfiYsvnigdvTsOEIwgA=\n=yKCo\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/filter_decrypt/files/hidden-json.yaml
+++ b/tests/integration/targets/filter_decrypt/files/hidden-json.yaml
@@ -1,0 +1,21 @@
+{
+	"a": "ENC[AES256_GCM,data:/Q==,iv:q+yypwZjX2frKGNruAFF+XSnmz+IU3AQ5XuUMWhhyhA=,tag:skm5wsq8a3/EESLVic8yKw==,type:str]",
+	"c": "ENC[AES256_GCM,data:DQ==,iv:JvvR1pXyp6L+i4keXDwLM79oxP6K1nqeGkIC5OgR38c=,tag:QbtjRLx47fN5M4+zaaQBVA==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-07T20:21:33Z",
+		"mac": "ENC[AES256_GCM,data:rbWY/H6bj2UFpybJHqsS02wjy8VMvNvzQUtd6fBMSsvvv1fYWWoULO32LGA635spoFkVyOpX4hipqVyjRfQ1KyP1rNssggaHMz+nRUUFOmiQAcT9wi/Y0IKWjgN1cjI1stCU10b5cfJZQ0SPi/OFC8KcptMaHpfDVF47ZfnprFs=,iv:rVtp2Ti4xHNOWeS4MKju1jFZ/VyE7oXXdTSpp4jSU34=,tag:kd0IeyLXY598kdvSX0+1DA==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-07T20:21:18Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAPQ6Bn3MlvYUPs+e0njFUoq4AZAhR38BIWGAzTAMeWfIH\n0JZwol5f1leoyKX5Bmye1S+n72zZz3C4FxhSqh80boxNpHuVyeLrAkzv25AaAS8Q\n/9mSYquvJcIL7nWX/QmgTVTaXrqlxZSVva6Slwf7zlaLBqVJfv1RDwT6JEWDIJig\nJp35PKpwRe70IZDGAelcDtJicmjQrvfVhyb1/0kTTv4JdylixVnQdh9X/zw5ZSBG\nusEW/JG9nZ/xzKsEQpafCBLhP80jx3z37zKbsJ+4K2xsBTGQQdU5KdDSnosw/L/b\nHlOCwaMQgb/dQPA5fpwVyGnVas6GK7gQvzznHAiHc9LgAeT0brybsEaAPOuA94/V\nA/ny4cub4Mzg0eFWf+C94i6lS1/gtuWI2PEva3259aEycV6gpYSOoPh3tYlBoVlM\ntj01l2eYfeBn5MNIWuhqfGTL4mLuzfiYsvnigdvTsOEIwgA=\n=yKCo\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/filter_decrypt/files/hidden-yaml
+++ b/tests/integration/targets/filter_decrypt/files/hidden-yaml
@@ -1,0 +1,27 @@
+a: ENC[AES256_GCM,data:lQ==,iv:8RdyROFAynjfYVNniCd0t8OQrFEboZREoBzAAOSudig=,tag:700olmYZs3sRhqcwnzor9A==,type:str]
+c: ENC[AES256_GCM,data:wQ==,iv:11sU7IEMYeDWHwNFsx6CgvUNG8Inc26vujykniuF+dc=,tag:ijRW/zjV+G0w3mwnHp4I8Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2020-10-07T20:21:14Z'
+    mac: ENC[AES256_GCM,data:QHcAe20/paYldZucaM1PN21K0i5ngS0UxMMryReTi9M40x9J18pNXo8TUoQuq/4iWZqgAKph1/m/u5pTU8LyKTeBX/HGlkWLjYUH521OJoBWJ0gDKHcZ01L3djlPi8Gts0w5MW/hrUlVqE3hyccy32VsCseuQckkq6dWnvtOmw4=,iv:dMqoZy2JhitE9dAwDxaI5q0NIo0N+rTiXjlnZBUG06k=,tag:8D9RcA8RGV6pCq/HLayGWw==,type:str]
+    pgp:
+    -   created_at: '2020-10-07T20:21:08Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgAmsvCa83tx8AfOH2cVM4DMNcFSPeR8hQcrILjkvcWqk5s
+            dd9YqTo+b6nxbZGcRUcvMmMOUo8OOIjVGyT7Yk6itLm2AFjY4T40wE2UyNEW3Jys
+            ZG3Tvel28T++FXquMhhs0iqfEOFDwRyOAbW/dDCEfzqmPGnjHNYiiE70EwJ6dlQG
+            xqhmUQrEgcdgBO9fmCsREA8IJt6z1Le1SGAQPhBAYwJU/Gr8OzI5GvlHj8vdLWmJ
+            dSPG62Ju6MhGIpOdkKY6zH/XVRFrP1v1LwJ+kigUFNuSORczITHPGFbH8Mpysp2G
+            uz1y+LX49Ynq1MApJxoCMSapWwYE1nv4w0eDwjLJzdLgAeThTu8/4A029VVXtiu9
+            dxtt4V0i4CPgkuFo0eB34hoAk4fgu+Vpe7jKQlaKKDYG0/hDUVcoEA+GBTO1GpKC
+            I0hrHJt5O+DY5Ecvy/je21+8tQOOfoohMT/i6tB0wuE56wA=
+            =NXWv
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/tests/integration/targets/filter_decrypt/files/hidden-yaml.json
+++ b/tests/integration/targets/filter_decrypt/files/hidden-yaml.json
@@ -1,0 +1,27 @@
+a: ENC[AES256_GCM,data:lQ==,iv:8RdyROFAynjfYVNniCd0t8OQrFEboZREoBzAAOSudig=,tag:700olmYZs3sRhqcwnzor9A==,type:str]
+c: ENC[AES256_GCM,data:wQ==,iv:11sU7IEMYeDWHwNFsx6CgvUNG8Inc26vujykniuF+dc=,tag:ijRW/zjV+G0w3mwnHp4I8Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2020-10-07T20:21:14Z'
+    mac: ENC[AES256_GCM,data:QHcAe20/paYldZucaM1PN21K0i5ngS0UxMMryReTi9M40x9J18pNXo8TUoQuq/4iWZqgAKph1/m/u5pTU8LyKTeBX/HGlkWLjYUH521OJoBWJ0gDKHcZ01L3djlPi8Gts0w5MW/hrUlVqE3hyccy32VsCseuQckkq6dWnvtOmw4=,iv:dMqoZy2JhitE9dAwDxaI5q0NIo0N+rTiXjlnZBUG06k=,tag:8D9RcA8RGV6pCq/HLayGWw==,type:str]
+    pgp:
+    -   created_at: '2020-10-07T20:21:08Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgAmsvCa83tx8AfOH2cVM4DMNcFSPeR8hQcrILjkvcWqk5s
+            dd9YqTo+b6nxbZGcRUcvMmMOUo8OOIjVGyT7Yk6itLm2AFjY4T40wE2UyNEW3Jys
+            ZG3Tvel28T++FXquMhhs0iqfEOFDwRyOAbW/dDCEfzqmPGnjHNYiiE70EwJ6dlQG
+            xqhmUQrEgcdgBO9fmCsREA8IJt6z1Le1SGAQPhBAYwJU/Gr8OzI5GvlHj8vdLWmJ
+            dSPG62Ju6MhGIpOdkKY6zH/XVRFrP1v1LwJ+kigUFNuSORczITHPGFbH8Mpysp2G
+            uz1y+LX49Ynq1MApJxoCMSapWwYE1nv4w0eDwjLJzdLgAeThTu8/4A029VVXtiu9
+            dxtt4V0i4CPgkuFo0eB34hoAk4fgu+Vpe7jKQlaKKDYG0/hDUVcoEA+GBTO1GpKC
+            I0hrHJt5O+DY5Ecvy/je21+8tQOOfoohMT/i6tB0wuE56wA=
+            =NXWv
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/tests/integration/targets/filter_decrypt/files/hidden-yaml.yaml
+++ b/tests/integration/targets/filter_decrypt/files/hidden-yaml.yaml
@@ -1,0 +1,27 @@
+a: ENC[AES256_GCM,data:lQ==,iv:8RdyROFAynjfYVNniCd0t8OQrFEboZREoBzAAOSudig=,tag:700olmYZs3sRhqcwnzor9A==,type:str]
+c: ENC[AES256_GCM,data:wQ==,iv:11sU7IEMYeDWHwNFsx6CgvUNG8Inc26vujykniuF+dc=,tag:ijRW/zjV+G0w3mwnHp4I8Q==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    lastmodified: '2020-10-07T20:21:14Z'
+    mac: ENC[AES256_GCM,data:QHcAe20/paYldZucaM1PN21K0i5ngS0UxMMryReTi9M40x9J18pNXo8TUoQuq/4iWZqgAKph1/m/u5pTU8LyKTeBX/HGlkWLjYUH521OJoBWJ0gDKHcZ01L3djlPi8Gts0w5MW/hrUlVqE3hyccy32VsCseuQckkq6dWnvtOmw4=,iv:dMqoZy2JhitE9dAwDxaI5q0NIo0N+rTiXjlnZBUG06k=,tag:8D9RcA8RGV6pCq/HLayGWw==,type:str]
+    pgp:
+      - created_at: '2020-10-07T20:21:08Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgAmsvCa83tx8AfOH2cVM4DMNcFSPeR8hQcrILjkvcWqk5s
+            dd9YqTo+b6nxbZGcRUcvMmMOUo8OOIjVGyT7Yk6itLm2AFjY4T40wE2UyNEW3Jys
+            ZG3Tvel28T++FXquMhhs0iqfEOFDwRyOAbW/dDCEfzqmPGnjHNYiiE70EwJ6dlQG
+            xqhmUQrEgcdgBO9fmCsREA8IJt6z1Le1SGAQPhBAYwJU/Gr8OzI5GvlHj8vdLWmJ
+            dSPG62Ju6MhGIpOdkKY6zH/XVRFrP1v1LwJ+kigUFNuSORczITHPGFbH8Mpysp2G
+            uz1y+LX49Ynq1MApJxoCMSapWwYE1nv4w0eDwjLJzdLgAeThTu8/4A029VVXtiu9
+            dxtt4V0i4CPgkuFo0eB34hoAk4fgu+Vpe7jKQlaKKDYG0/hDUVcoEA+GBTO1GpKC
+            I0hrHJt5O+DY5Ecvy/je21+8tQOOfoohMT/i6tB0wuE56wA=
+            =NXWv
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.6.1

--- a/tests/integration/targets/filter_decrypt/files/rstrip.sops
+++ b/tests/integration/targets/filter_decrypt/files/rstrip.sops
@@ -1,0 +1,20 @@
+{
+	"data": "ENC[AES256_GCM,data:+x5Q1yGxpgvMQiwwMiCAiU0B5KA7i1eMvuRRxNLpKH0LEEs/7rpOInqKtA==,iv:96ihzWMxW45FqN28BCtX1emDBcXln9FN87Yf8bTlbbA=,tag:a8SiDQjFffOYHwKp5IhU2Q==,type:str]",
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-10-02T18:14:42Z",
+		"mac": "ENC[AES256_GCM,data:CyLyYbG6rVwT8sRqLxLBuWUrgtUHz8XVwCx7iyiJDL925jzMvkA2ZEYxH6CsiWwc5/7tcFGLDSCjYw3AHD9x42LmsaAefk7F4X55++EI5VZbmSwyHdxCqvMVycKLJm3YXfodos8bbEWDDXhbmMT92uJs7H/IBXywnQHG3qoJWJE=,iv:ljY/d++R5v8VY5Q8nV0lnNwaeuEiKG4VTY8fSgFJD+w=,tag:MEtTIFuiSj8ReQOZNxO1IQ==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-10-02T18:11:54Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAblvrgBIPsg01TJjde7YskLvPKC/1jt1kI/eoOQ/KdemW\ngaJf4PIWGzFUxZEXeRzo70HTS+sPTi0TQDDkwOfcNjlGb3dC1KQdIZ1UiuqhL1//\n1G0doMMztEyZ63SOElv3OaWHjcnvmP224rTuFpO6Pm8HHMKEbaw9N7YHObgSdIpk\nfqEP369xj6bk/yQNEuMbgQOk+7LAYPs8na7oxIrdkWrmIlVj5jEz08lVS/FJecty\nUDalNDBkRrqMgTvSAw0vJTzaPzw/V+6WTrHh/0FRvLKJlKOsesaoxahW2/H1Dxmr\npySYTs2omqOtr3RzkCrUXmHijim9DIwg0JsIjo5xytLgAeSjSr9/W1EucekSGbeM\nmYK+4cN/4ILgRuH75OAw4qu0IgrgWuX6Eo7vO2HPrUiFLA/j+7/Bi+HkBZZuMrlR\njhd7C7MQGuD85NF3TzP2hW895ZiDznjWutHi69caRuEeZQA=\n=Aqvj\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/filter_decrypt/files/simple.sops.yaml
+++ b/tests/integration/targets/filter_decrypt/files/simple.sops.yaml
@@ -1,0 +1,25 @@
+foo: ENC[AES256_GCM,data:a25L,iv:X8ILHZr+YiyLWa90Y+cwoMD1nVuel7JyTs0A5+oiOOo=,tag:GbBtp+Yqx1KEjdyztqS4EQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2020-02-20T10:44:32Z'
+    mac: ENC[AES256_GCM,data:BAwQqD9sHgHkmlxPQLKq28Xy48qPp1B/+GDLEsIxir6WNhZgw8OgjVF1u/wCAad6qHkmN02Bwenr+aay6uKfCuOEsTRSvZ7v80yAU+h0wL3zJ/KMkRsE3QP3CWxcLQxInt+YaBjR+Q0IUjDXKm3u6ZomixZe5F5pwWr36ErV6Y0=,iv:e/iiyXQiCh8C2w/bc8mr/Psv+ehmqEMqEC1/bbGFHpY=,tag:NSDo2HISIBJhYvsqrU0mSA==,type:str]
+    pgp:
+      - created_at: '2020-02-20T10:44:32Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgALJTUwdx6rAPckJ+reP5TEq+lXzHI1Zi7aHYOqZQBnA2s
+            z8h1gRce/fn7RPkmdsjsdSYmxGGKqwDXxUYsbN1aWXk6mb4Juktdvjl/GndF6PkU
+            TiN/l1GM6upgS+GPxA01NKsGkVmEtKR5NhsNEnE6OzY29+PFLsBX2vO1Zfg7kzBz
+            cDl6PT8fbFTEaFeyuYl9IslIV8yYsj1oHL3CF76RjCP6b18NSOHM23ytlH+KVaBV
+            ntoSVkTyWDx5o9iEHBEWSEGNpaCWWiEgkDEkA1VqMHdUlsW+IjZ8ggg5NJbcVtrG
+            YkN8rlGsNEzx+g4O4b1160A2K6AdTBcoGHwHD3u3XdLgAeTqT1ekE2N3yNT6w4sm
+            6uET4eTS4Cvg1OFCgOC34uUzlY3gbuVy20h8RNyQoAfhSN4DD2MexKqcMMCVCtn0
+            OhRMTP2jjOCe5Ex3/p3awcVxwx7qeJ26Vnfiwtg6ueFI5AA=
+            =tcnq
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.4.0

--- a/tests/integration/targets/filter_decrypt/meta/main.yml
+++ b/tests/integration/targets/filter_decrypt/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - setup_sops

--- a/tests/integration/targets/filter_decrypt/tasks/main.yml
+++ b/tests/integration/targets/filter_decrypt/tasks/main.yml
@@ -1,6 +1,27 @@
 ---
 - when: sops_installed
   block:
+    - name: Test bad parameter detection (1/2)
+      set_fact:
+        sops_bad_input_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(input_type='foo') }}"
+      ignore_errors: yes
+      register: sops_bad_input_type
+
+    - name: Test bad parameter detection (2/2)
+      set_fact:
+        sops_bad_output_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(output_type=23) }}"
+      ignore_errors: yes
+      register: sops_bad_output_type
+
+    - assert:
+        that:
+          - "sops_bad_input_type is failed"
+          - "'input_type must be one of' in sops_bad_input_type.msg"
+          - "'; got \"foo\"' in sops_bad_input_type.msg"
+          - "sops_bad_output_type is failed"
+          - "'output_type must be one of' in sops_bad_output_type.msg"
+          - "'; got \"23\"' in sops_bad_output_type.msg"
+
     - name: Test decrypt of non-sops file
       set_fact:
         sops_wrong_file: "{{ 'this-is-not: a sops file' | community.sops.decrypt }}"

--- a/tests/integration/targets/filter_decrypt/tasks/main.yml
+++ b/tests/integration/targets/filter_decrypt/tasks/main.yml
@@ -1,0 +1,108 @@
+---
+- when: sops_installed
+  block:
+    - name: Test decrypt of non-sops file
+      set_fact:
+        sops_wrong_file: "{{ 'this-is-not: a sops file' | community.sops.decrypt }}"
+      ignore_errors: yes
+      register: sops_filter_wrong_file
+
+    - assert:
+        that:
+          - "sops_filter_wrong_file is failed"
+          - "'sops metadata not found' in sops_filter_wrong_file.msg"
+
+    - name: Test simple filter
+      set_fact:
+        sops_success: "{{ lookup('file', 'simple.sops.yaml') | community.sops.decrypt }}"
+      ignore_errors: yes
+      register: sops_filter_simple
+
+    - assert:
+        that:
+          - "sops_filter_simple is success"
+          - "sops_success == 'foo: bar'"
+
+    - name: Test rstrip
+      set_fact:
+        with_rstrip: "{{ lookup('file', 'rstrip.sops') | community.sops.decrypt(rstrip=true, output_type='binary') }}"
+        without_rstrip: "{{ lookup('file', 'rstrip.sops') | community.sops.decrypt(rstrip=false, output_type='binary') }}"
+        default_rstrip: "{{ lookup('file', 'rstrip.sops') | community.sops.decrypt(output_type='binary') }}"
+
+    - assert:
+        that:
+          - with_rstrip == 'This file has three newlines at the end.'
+          - without_rstrip == 'This file has three newlines at the end.\n\n\n'
+          - default_rstrip == 'This file has three newlines at the end.'
+
+    - name: Test binary
+      set_fact:
+        binary_with_rstrip: "{{ lookup('file', 'binary.sops') | community.sops.decrypt(rstrip=true, decode_output=false, output_type='binary') | b64encode }}"
+        binary_without_rstrip: "{{ lookup('file', 'binary.sops') | community.sops.decrypt(rstrip=false, decode_output=false, output_type='binary') | b64encode }}"
+
+    - assert:
+        that:
+          - binary_with_rstrip == 'AQIDAAQ='
+          - binary_without_rstrip == 'AQIDAAQgCg=='
+
+    - name: Test hidden binary
+      set_fact:
+        hidden_binary: "{{ lookup('file', 'hidden-binary') | community.sops.decrypt(output_type='binary') }}"
+        hidden_binary__json: "{{ lookup('file', 'hidden-binary.json') | community.sops.decrypt(output_type='binary') }}"
+        hidden_binary__yaml: "{{ lookup('file', 'hidden-binary.yaml') | community.sops.decrypt(output_type='binary') }}"
+        hidden_binary_yaml: "{{ lookup('file', 'hidden-binary-yaml') | community.sops.decrypt(input_type='yaml', output_type='binary') }}"
+        hidden_binary_yaml__json: "{{ lookup('file', 'hidden-binary-yaml.json') | community.sops.decrypt(input_type='yaml', output_type='binary') }}"
+        hidden_binary_yaml__yaml: "{{ lookup('file', 'hidden-binary-yaml.yaml') | community.sops.decrypt(input_type='yaml', output_type='binary') }}"
+        hidden_json: "{{ lookup('file', 'hidden-json') | community.sops.decrypt(input_type='json', output_type='json') }}"
+        hidden_json__json: "{{ lookup('file', 'hidden-json.json') | community.sops.decrypt(input_type='json', output_type='json') }}"
+        hidden_json__yaml: "{{ lookup('file', 'hidden-json.yaml') | community.sops.decrypt(input_type='json', output_type='json') }}"
+        hidden_yaml: "{{ lookup('file', 'hidden-yaml') | community.sops.decrypt(input_type='yaml', output_type='yaml') }}"
+        hidden_yaml__json: "{{ lookup('file', 'hidden-yaml.json') | community.sops.decrypt(input_type='yaml', output_type='yaml') }}"
+        hidden_yaml__yaml: "{{ lookup('file', 'hidden-yaml.yaml') | community.sops.decrypt(input_type='yaml', output_type='yaml') }}"
+        hidden_json__as_yaml: "{{ lookup('file', 'hidden-json') | community.sops.decrypt(input_type='json', output_type='yaml') }}"
+        hidden_json__json__as_yaml: "{{ lookup('file', 'hidden-json.json') | community.sops.decrypt(input_type='json', output_type='yaml') }}"
+        hidden_json__yaml__as_yaml: "{{ lookup('file', 'hidden-json.yaml') | community.sops.decrypt(input_type='json', output_type='yaml') }}"
+        hidden_yaml__as_json: "{{ lookup('file', 'hidden-yaml') | community.sops.decrypt(input_type='yaml', output_type='json') }}"
+        hidden_yaml__json__as_json: "{{ lookup('file', 'hidden-yaml.json') | community.sops.decrypt(input_type='yaml', output_type='json') }}"
+        hidden_yaml__yaml__as_json: "{{ lookup('file', 'hidden-yaml.yaml') | community.sops.decrypt(input_type='yaml', output_type='json') }}"
+
+    - assert:
+        that:
+          - hidden_binary == test_str_abcd
+          - hidden_binary__json == test_str_abcd
+          - hidden_binary__yaml == test_str_abcd
+          - hidden_binary_yaml == test_str_binary_data
+          - hidden_binary_yaml__json == test_str_binary_data
+          - hidden_binary_yaml__yaml == test_str_binary_data
+          - hidden_json == test_dict
+          - hidden_json__json == test_dict
+          - hidden_json__yaml == test_dict
+          - hidden_yaml == test_dict_yaml
+          - hidden_yaml__json == test_dict_yaml
+          - hidden_yaml__yaml == test_dict_yaml
+          - hidden_json__as_yaml == test_dict_yaml
+          - hidden_json__json__as_yaml == test_dict_yaml
+          - hidden_json__yaml__as_yaml == test_dict_yaml
+          - hidden_yaml__as_json == test_dict
+          - hidden_yaml__json__as_json == test_dict
+          - hidden_yaml__yaml__as_json == test_dict
+      vars:
+        test_dict:
+          a: b
+          c: d
+        test_dict_yaml:
+          "a: b\nc: d"
+        test_str_binary_data: This is binary data.
+        test_str_abcd: a is b, and c is d
+
+    - name: Test fake sops binary
+      set_fact:
+        fake_sops_output: "{{ lookup('file', 'simple.sops.yaml') | community.sops.decrypt(sops_binary=role_path ~ '/files/fake-sops.sh', enable_local_keyservice=True, aws_access_key_id='xxx') }}"
+        fake_sops_output_2: "{{ lookup('file', 'simple.sops.yaml') | community.sops.decrypt(sops_binary=role_path ~ '/files/fake-sops-val.sh', config_path='/path/to/asdf', aws_secret_access_key='yyy') }}"
+        fake_sops_output_3: "{{ lookup('file', 'simple.sops.yaml') | community.sops.decrypt(sops_binary=role_path ~ '/files/fake-sops-rep.sh', keyservice=['a', 'b'], aws_session_token='zzz') }}"
+
+    - assert:
+        that:
+          - fake_sops_output == 'fake sops output'
+          - fake_sops_output_2 == 'fake sops output 2'
+          - fake_sops_output_3 == 'fake sops output 3'

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,2 +1,4 @@
+tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
+tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-json.yaml yamllint:error

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,2 +1,4 @@
+tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
+tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-json.yaml yamllint:error

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,2 +1,4 @@
+tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
+tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-json.yaml yamllint:error

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,2 +1,4 @@
+tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
+tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-json.yaml yamllint:error


### PR DESCRIPTION
Fixes #67.

Implements a Jinja2 filter `community.sops.decrypt` which can be used to decrypt sops-encrypted data loaded from some source.

(Will add some documentation once #70 is merged.)