### PR TITLE
Replace ansible.module_utils._text by ansible.module_utils.common.text.converters

### DIFF
--- a/changelogs/fragments/ansible-core-_text.yml
+++ b/changelogs/fragments/ansible-core-_text.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "Avoid internal ansible-core module_utils in favor of equivalent public API available since at least Ansible 2.9 (https://github.com/ansible-collections/community.sops/pull/73)."

--- a/plugins/action/load_vars.py
+++ b/plugins/action/load_vars.py
@@ -10,7 +10,7 @@ import re
 from ansible.module_utils.common.validation import check_type_bool, check_type_str
 from ansible.module_utils.common._collections_compat import Sequence, Mapping
 from ansible.module_utils.six import iteritems, string_types
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.action import ActionBase
 from ansible.utils.display import Display
 

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 from ansible.errors import AnsibleError, AnsibleFilterError
-from ansible.module_utils._text import to_bytes, to_native
+from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.utils.display import Display
 
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -114,7 +114,7 @@ import base64
 
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
 
 from ansible.utils.display import Display

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -9,7 +9,7 @@ import abc
 import os
 
 from ansible.module_utils import six
-from ansible.module_utils._text import to_text, to_native
+from ansible.module_utils.common.text.converters import to_text, to_native
 
 # Since this is used both by plugins and modules, we need subprocess in case the `module` parameter is not used
 from subprocess import Popen, PIPE

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -87,7 +87,7 @@ import os
 import traceback
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.community.sops.plugins.module_utils.io import write_file
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError, get_sops_argument_spec

--- a/plugins/plugin_utils/action_module.py
+++ b/plugins/plugin_utils/action_module.py
@@ -60,7 +60,7 @@ from ansible.module_utils.six import (
     string_types,
     text_type,
 )
-from ansible.module_utils._text import to_native, to_text
+from ansible.module_utils.common.text.converters import to_native, to_text
 from ansible.plugins.action import ActionBase
 
 

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -69,7 +69,7 @@ DOCUMENTATION = '''
 
 import os
 from ansible.errors import AnsibleParserError
-from ansible.module_utils._text import to_bytes, to_native, to_text
+from ansible.module_utils.common.text.converters import to_bytes, to_native, to_text
 from ansible.plugins.vars import BaseVarsPlugin
 from ansible.inventory.host import Host
 from ansible.inventory.group import Group


### PR DESCRIPTION
##### SUMMARY
While the private API `ansible.module_utils._text` was the default place to get `to_text`, `to_bytes` and `to_native` for a long time, at least since Ansible 2.9 there's a non-private alternative: `ansible.module_utils.common.text.converters`. So let's use it :)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
various plugins
