### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ By using `{{ encrypted_data | community.sops.decrypt }}` instead of `{{ decrypte
 ### vars plugin
 
 Vars plugins only work in ansible >= 2.10 and require explicit enabling.  One
-way to enable the plugin is by adding the following to the `default` section of
+way to enable the plugin is by adding the following to the `defaults` section of
 your `ansible.cfg`:
 
 ```ini

--- a/docs/docsite/rst/guide.rst
+++ b/docs/docsite/rst/guide.rst
@@ -331,7 +331,7 @@ To use the vars plugin, you need to enable it in your Ansible config file (``ans
 
 .. code-block:: ini
 
-    [default]
+    [defaults]
     vars_plugins_enabled = host_group_vars,community.sops.sops
 
 See :ref:`VARIABLE_PLUGINS_ENABLED <VARIABLE_PLUGINS_ENABLED>` for more details on enabling vars plugins. Then you can put files with the following extensions into the ``group_vars`` and ``host_vars`` directories:


### PR DESCRIPTION
Change `default` to `defaults`. The section in ansible.cfg is `defaults` not `default`.

### Motivation
Documentation tells us that the section in ansible.cfg is default. It is not default but defaults.

### Changes description
Update README.md