### PR TITLE
Also collect coverage during sanity tests

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -41,8 +41,16 @@ jobs:
       # run ansible-test sanity inside of Docker.
       # The docker container has all the pinned dependencies that are required.
       - name: Run sanity tests
-        run: ansible-test sanity --docker -v --color
+        run: ansible-test sanity --docker -v --color --coverage
         working-directory: ./ansible_collections/community/sops
+
+      - name: Generate coverage report.
+        run: ansible-test coverage xml -v --requirements --group-by command --group-by version
+        working-directory: ./ansible_collections/community/sops
+
+      - uses: codecov/codecov-action@v2
+        with:
+          fail_ci_if_error: false
 
   integration:
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### SUMMARY
Enables coverage for sanity tests. This is somewhat experimental since I'm not 100% sure what the result will be. From glancing at the code, I *think* this mostly affects the import sanity test, so that some of the code which handles failing imports will show up in coverage reports.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
