### PR TITLE
Add filter documentation

### DIFF
--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -6,6 +6,97 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
+DOCUMENTATION = '''
+name: decrpyt
+short_description: Decrypt sops encrypted data
+version_added: 1.1.0
+author:
+    - Felix Fontein (@felixfontein)
+description:
+    - Decrypt sops encrypted data.
+    - Allows to decrypt data that has been provided by an arbitrary source.
+    - Note that due to Ansible lazy-evaluating expressions, it is better to use M(ansible.builtin.set_fact)
+      to store the result of an evaluation in a fact to avoid recomputing the value every time the expression
+      is used.
+options:
+    _input:
+        description:
+            - The data to decrypt.
+        type: string
+        required: true
+    rstrip:
+        description:
+            - Whether to remove trailing newlines and spaces.
+        type: bool
+        default: true
+    input_type:
+        description:
+            - Tell sops how to interpret the encrypted data.
+            - There is no auto-detection since we do not have a filename. By default
+              sops is told to treat the input as YAML. If that is wrong, please set this
+              option to the correct value.
+        type: str
+        choices:
+            - binary
+            - json
+            - yaml
+            - dotenv
+        default: yaml
+    output_type:
+        description:
+            - Tell sops how to interpret the decrypted file.
+            - Please note that the output is always text or bytes, depending on the value of I(decode_output).
+              To parse the resulting JSON or YAML, use corresponding filters such as C(ansible.builtin.from_json)
+              and C(ansible.builtin.from_yaml).
+        type: str
+        choices:
+            - binary
+            - json
+            - yaml
+            - dotenv
+        default: yaml
+    decode_output:
+        description:
+            - Whether to decode the output to bytes.
+            - When I(output_type=binary), and the file isn't known to contain UTF-8 encoded text,
+              this should better be set to C(false) to prevent mangling the data with UTF-8 decoding.
+        type: bool
+        default: true
+extends_documentation_fragment:
+    - community.sops.sops
+'''
+
+EXAMPLES = '''
+- name: Decrypt file fetched from URL
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Fetch file from URL
+      ansible.builtin.uri:
+        url: https://raw.githubusercontent.com/mozilla/sops/master/functional-tests/res/comments.enc.yaml
+        return_content: yes
+      register: encrypted_content
+
+    - name: Show encrypted data
+      debug:
+        msg: "{{ encrypted_content.content | ansible.builtin.from_yaml }}"
+
+    - name: Decrypt data and decode decrypted YAML
+      set_fact:
+        decrypted_data: "{{ encrypted_content.content | community.sops.decrypt | ansible.builtin.from_yaml }}"
+
+    - name: Show decrypted data
+      debug:
+        msg: "{{ decrypted_data }}"
+'''
+
+RETURN = '''
+_value:
+    description:
+        - Decrypted data as text (I(decode_output=true), default) or binary string (I(decode_output=false)).
+    type: string
+'''
+
 from ansible.errors import AnsibleError, AnsibleFilterError
 from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.utils.display import Display
@@ -18,7 +109,7 @@ _VALID_TYPES = set(['binary', 'json', 'yaml', 'dotenv'])
 
 def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sops', rstrip=True, decode_output=True,
                    aws_profile=None, aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None,
-                   config_path=None, enable_local_keyservice=None, keyservice=None):
+                   config_path=None, enable_local_keyservice=False, keyservice=None):
     '''Decrypt sops-encrypted data.'''
 
     # Check parameters

--- a/tests/sanity/extra/no-unwanted-files.py
+++ b/tests/sanity/extra/no-unwanted-files.py
@@ -6,6 +6,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import os
+import os.path
 import sys
 
 
@@ -26,6 +27,11 @@ def main():
     skip_directories = (
     )
 
+    yaml_directories = (
+        'plugins/test/',
+        'plugins/filter/',
+    )
+
     for path in paths:
         if path in skip_paths:
             continue
@@ -33,7 +39,15 @@ def main():
         if any(path.startswith(skip_directory) for skip_directory in skip_directories):
             continue
 
+        if os.path.islink(path):
+            print('%s: is a symbolic link' % (path, ))
+        elif not os.path.isfile(path):
+            print('%s: is not a regular file' % (path, ))
+
         ext = os.path.splitext(path)[1]
+
+        if ext in ('.yml', ) and any(path.startswith(yaml_directory) for yaml_directory in yaml_directories):
+            continue
 
         if ext not in allowed_extensions:
             print('%s: extension must be one of: %s' % (path, ', '.join(allowed_extensions)))


### PR DESCRIPTION
##### SUMMARY
Add filter documentation using the new sidecar docs feature for ansible-core 2.13. Rendered with https://github.com/ansible-community/antsibull-docs/pull/6 to: https://ansible.fontein.de/collections/community/sops/index.html#filter-plugins

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
filter plugin documentation
