### PR TITLE
Added configuration to temporarily disable the vars plugin (eg in AWX).

### DIFF
--- a/changelogs/fragments/114-disable-vars-plugin.yml
+++ b/changelogs/fragments/114-disable-vars-plugin.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "sops vars plugin - added a configuration option to temporarily disable the vars plugin (https://github.com/ansible-collections/community.sops/pull/114)."

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -49,6 +49,15 @@ DOCUMENTATION = '''
             section: community.sops
         env:
           - name: ANSIBLE_VARS_SOPS_PLUGIN_CACHE
+      _disable_vars_plugin_temporarily:
+        description:
+          - Temporarily disable this plugin.
+          - Useful if ansible-inventory is supposed to be run without decrypting secrets (in AWX for instance).
+        type: bool
+        default: false
+        version_added: 1.3.0
+        env:
+          - name: SOPS_ANSIBLE_AWX_DISABLE_VARS_PLUGIN_TEMPORARILY
     extends_documentation_fragment:
         - ansible.builtin.vars_plugin_staging
         - community.sops.sops
@@ -89,6 +98,9 @@ class VarsModule(BaseVarsPlugin):
 
         if cache is None:
             cache = self.get_option('cache')
+
+        if self.get_option('_disable_vars_plugin_temporarily'):
+            return {}
 
         data = {}
         for entity in entities:

--- a/tests/integration/targets/var_sops/test-disable-sops/group_vars
+++ b/tests/integration/targets/var_sops/test-disable-sops/group_vars
@@ -1,0 +1,1 @@
+../test-success/group_vars

--- a/tests/integration/targets/var_sops/test-disable-sops/hosts
+++ b/tests/integration/targets/var_sops/test-disable-sops/hosts
@@ -1,0 +1,1 @@
+../test-success/hosts

--- a/tests/integration/targets/var_sops/test-disable-sops/playbook.yml
+++ b/tests/integration/targets/var_sops/test-disable-sops/playbook.yml
@@ -1,0 +1,11 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Make sure group_vars/all.sops.yaml was not loaded.
+      debug:
+        msg: '{{ foo }}' # Will throw an undefined error.

--- a/tests/integration/targets/var_sops/test-disable-sops/run.sh
+++ b/tests/integration/targets/var_sops/test-disable-sops/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+SOPS_ANSIBLE_AWX_DISABLE_VARS_PLUGIN_TEMPORARILY=true \
+ansible-playbook playbook.yml -i hosts -v "$@"

--- a/tests/integration/targets/var_sops/test-disable-sops/validate.sh
+++ b/tests/integration/targets/var_sops/test-disable-sops/validate.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -eux
+
+if [ "$1" != 2 ]; then
+    exit 1
+fi
+
+grep -F "The error was: 'foo' is undefined" "$2"


### PR DESCRIPTION
### Motivation
AWX stores all variables that it can parse which is very bad for security sensitive stuff :)

### Changes description
I added a new env variable `SOPS_ANSIBLE_AWX_DISABLE_VARS_PLUGIN_TEMPORARILY` to disable the plugin temporarily. Can be used in AWX via a custom credential on the inventory source.

### Additional notes
<!-- any note related to these changes, please add them here -->
