### PR TITLE
CI: avoid running install roles more than twice (localhost and remote) for tests

### DIFF
--- a/tests/integration/targets/setup_sops/tasks/install.yml
+++ b/tests/integration/targets/setup_sops/tasks/install.yml
@@ -1,0 +1,49 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Install sops on localhost
+  include_role:
+    name: community.sops.install
+  vars:
+    sops_install_on_localhost: true
+    sops_version: '{{ override_sops_version | default("latest") }}'
+
+- name: Install age on localhost
+  include_role:
+    name: community.sops._install_age
+  vars:
+    sops_install_on_localhost: true
+
+- name: Download sops test GPG key on localhost
+  get_url:
+    url: https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc
+    dest: /tmp/sops_functional_tests_key.asc
+  delegate_to: localhost
+
+- name: Import sops test GPG key on localhost
+  command: gpg --import /tmp/sops_functional_tests_key.asc
+  ignore_errors: true
+  delegate_to: localhost
+
+# ---------------------------------------------------------------------------
+
+- name: Install sops on remote
+  include_role:
+    name: community.sops.install
+  vars:
+    sops_version: '{{ override_sops_version | default("latest") }}'
+
+- name: Install age on remote
+  include_role:
+    name: community.sops._install_age
+
+- name: Download sops test GPG key on remote
+  get_url:
+    url: https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc
+    dest: /tmp/sops_functional_tests_key.asc
+
+- name: Import sops test GPG key on remote
+  command: gpg --import /tmp/sops_functional_tests_key.asc
+  ignore_errors: true

--- a/tests/integration/targets/setup_sops/tasks/main.yml
+++ b/tests/integration/targets/setup_sops/tasks/main.yml
@@ -3,47 +3,26 @@
 # GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
-- name: Install sops on localhost
-  include_role:
-    name: community.sops.install
-  vars:
-    sops_install_on_localhost: true
-    sops_version: '{{ override_sops_version | default("latest") }}'
-
-- name: Install age on localhost
-  include_role:
-    name: community.sops._install_age
-  vars:
-    sops_install_on_localhost: true
-
-- name: Download sops test GPG key on localhost
-  get_url:
-    url: https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc
-    dest: /tmp/sops_functional_tests_key.asc
-  delegate_to: localhost
-
-- name: Import sops test GPG key on localhost
-  command: gpg --import /tmp/sops_functional_tests_key.asc
+- name: Test whether sops is installed
+  command: sops --help
   ignore_errors: true
-  delegate_to: localhost
+  changed_when: false
+  register: sops_help_command
 
-# ---------------------------------------------------------------------------
+- name: Install sops
+  include_tasks: install.yml
+  when: sops_help_command is failed
 
-- name: Install sops on remote
-  include_role:
-    name: community.sops.install
-  vars:
-    sops_version: '{{ override_sops_version | default("latest") }}'
+- name: Skip sops installation
+  when: sops_help_command is not failed
+  block:
+    - name: Test whether age is installed
+      command: age --version
+      ignore_errors: true
+      changed_when: false
+      register: age_version_command
 
-- name: Install age on remote
-  include_role:
-    name: community.sops._install_age
-
-- name: Download sops test GPG key on remote
-  get_url:
-    url: https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc
-    dest: /tmp/sops_functional_tests_key.asc
-
-- name: Import sops test GPG key on remote
-  command: gpg --import /tmp/sops_functional_tests_key.asc
-  ignore_errors: true
+    - name: Set results
+      set_fact:
+        sops_installed: true
+        age_installed: '{{ age_version_command is not failed }}'


### PR DESCRIPTION
This should make CI more reliable. Right now it often fails with GitHub API rate limitings (see for example https://github.com/ansible-collections/community.sops/actions/runs/3728549456/jobs/6324270637) since the install role (with latest) is run multiple times per CI run.