### PR TITLE
CI: Use Fedora 37 container instead of Fedora 36 container, which has been removed from devel

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -68,7 +68,7 @@ jobs:
         docker_container:
           - ubuntu2004
           - ubuntu2204
-          - fedora36
+          - fedora37
         sops_version:
           - 3.5.0
           - 3.6.0
@@ -197,7 +197,7 @@ jobs:
             target: gha/install/3/
             github_latest_detection: auto
           - ansible: devel
-            docker_container: fedora36
+            docker_container: fedora37
             python_version: ''
             target: gha/install/3/
             github_latest_detection: auto


### PR DESCRIPTION
Currently CI fails because of this.
