### PR TITLE
CI: Arch Linux now uses Python 3.11

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -111,7 +111,7 @@ jobs:
           # devel
           - ansible: devel
             docker_container: quay.io/ansible-community/test-image:archlinux
-            python_version: '3.10'
+            python_version: '3.11'
             sops_version: latest
           - ansible: devel
             docker_container: quay.io/ansible-community/test-image:debian-bullseye
@@ -185,7 +185,7 @@ jobs:
           # Install latest sops
           - ansible: devel
             docker_container: quay.io/ansible-community/test-image:archlinux
-            python_version: '3.10'
+            python_version: '3.11'
             target: gha/install/3/
             github_latest_detection: auto
             # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)


### PR DESCRIPTION
##### SUMMARY
Ref: https://github.com/ansible-community/images/pull/56
Ref: https://github.com/ansible-collections/news-for-maintainers/issues/43

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
