### PR TITLE
Integration tests: use failed_when instead of ignore_errors

### DIFF
--- a/tests/ee/all.yml
+++ b/tests/ee/all.yml
@@ -11,7 +11,7 @@
         dest: /tmp/sops_functional_tests_key.asc
     - name: Import sops test GPG key on localhost
       command: gpg --import /tmp/sops_functional_tests_key.asc
-      ignore_errors: true
+      failed_when: false
     - name: Find all roles
       find:
         paths:

--- a/tests/ee/roles/lookup_sops/tasks/main.yml
+++ b/tests/ee/roles/lookup_sops/tasks/main.yml
@@ -38,7 +38,6 @@
 - name: Test simple lookup
   set_fact:
     sops_success: "{{ lookup('community.sops.sops', 'simple.sops.yaml') }}"
-  ignore_errors: true
   register: sops_lookup_simple
 
 - assert:

--- a/tests/integration/targets/age/tasks/test.yml
+++ b/tests/integration/targets/age/tasks/test.yml
@@ -104,17 +104,19 @@
 - name: Failed encryption 1
   debug:
     msg: "{{ lookup('community.sops.sops', local_tmp_dir ~ '/enc-2.sops.yaml', age_keyfile=local_tmp_dir ~ '/identity_3') | from_yaml }}"
+  ignore_errors: true
   register: failure_1
-  failed_when: failure_1 is not failed
 
 - name: Failed encryption 2
   debug:
     msg: "{{ lookup('community.sops.sops', local_tmp_dir ~ '/enc-3.sops.yaml', age_keyfile=local_tmp_dir ~ '/identity_1') | from_yaml }}"
+  ignore_errors: true
   register: failure_2
-  failed_when: failure_2 is not failed
 
 - name: Validate failed decryption
   assert:
     that:
+      - failure_1 is failed
       - "'CouldNotRetrieveKey' in failure_1.msg"
+      - failure_2 is failed
       - "'CouldNotRetrieveKey' in failure_2.msg"

--- a/tests/integration/targets/age/tasks/test.yml
+++ b/tests/integration/targets/age/tasks/test.yml
@@ -116,7 +116,5 @@
 - name: Validate failed decryption
   assert:
     that:
-      - failure_1 is failed
       - "'CouldNotRetrieveKey' in failure_1.msg"
-      - failure_2 is failed
       - "'CouldNotRetrieveKey' in failure_2.msg"

--- a/tests/integration/targets/age/tasks/test.yml
+++ b/tests/integration/targets/age/tasks/test.yml
@@ -104,14 +104,14 @@
 - name: Failed encryption 1
   debug:
     msg: "{{ lookup('community.sops.sops', local_tmp_dir ~ '/enc-2.sops.yaml', age_keyfile=local_tmp_dir ~ '/identity_3') | from_yaml }}"
-  ignore_errors: true
   register: failure_1
+  failed_when: failure_1 is not failed
 
 - name: Failed encryption 2
   debug:
     msg: "{{ lookup('community.sops.sops', local_tmp_dir ~ '/enc-3.sops.yaml', age_keyfile=local_tmp_dir ~ '/identity_1') | from_yaml }}"
-  ignore_errors: true
   register: failure_2
+  failed_when: failure_2 is not failed
 
 - name: Validate failed decryption
   assert:

--- a/tests/integration/targets/filter_decrypt/tasks/main.yml
+++ b/tests/integration/targets/filter_decrypt/tasks/main.yml
@@ -8,30 +8,33 @@
     - name: Test bad parameter detection (1/2)
       set_fact:
         sops_bad_input_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(input_type='foo') }}"
+      ignore_errors: true
       register: sops_bad_input_type
-      failed_when: sops_bad_input_type is not failed
 
     - name: Test bad parameter detection (2/2)
       set_fact:
         sops_bad_output_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(output_type=23) }}"
+      ignore_errors: true
       register: sops_bad_output_type
-      failed_when: sops_bad_output_type is not failed
 
     - assert:
         that:
+          - "sops_bad_input_type is failed"
           - "'input_type must be one of' in sops_bad_input_type.msg"
           - "'; got \"foo\"' in sops_bad_input_type.msg"
+          - "sops_bad_output_type is failed"
           - "'output_type must be one of' in sops_bad_output_type.msg"
           - "'; got \"23\"' in sops_bad_output_type.msg"
 
     - name: Test decrypt of non-sops file
       set_fact:
         sops_wrong_file: "{{ 'this-is-not: a sops file' | community.sops.decrypt }}"
+      ignore_errors: true
       register: sops_filter_wrong_file
-      failed_when: sops_filter_wrong_file is not failed
 
     - assert:
         that:
+          - "sops_filter_wrong_file is failed"
           - "'sops metadata not found' in sops_filter_wrong_file.msg"
 
     - name: Test simple filter

--- a/tests/integration/targets/filter_decrypt/tasks/main.yml
+++ b/tests/integration/targets/filter_decrypt/tasks/main.yml
@@ -19,10 +19,8 @@
 
     - assert:
         that:
-          - "sops_bad_input_type is failed"
           - "'input_type must be one of' in sops_bad_input_type.msg"
           - "'; got \"foo\"' in sops_bad_input_type.msg"
-          - "sops_bad_output_type is failed"
           - "'output_type must be one of' in sops_bad_output_type.msg"
           - "'; got \"23\"' in sops_bad_output_type.msg"
 
@@ -34,14 +32,12 @@
 
     - assert:
         that:
-          - "sops_filter_wrong_file is failed"
           - "'sops metadata not found' in sops_filter_wrong_file.msg"
 
     - name: Test simple filter
       set_fact:
         sops_success: "{{ lookup('file', 'simple.sops.yaml') | community.sops.decrypt }}"
       register: sops_filter_simple
-      failed_when: sops_filter_simple is not failed
 
     - assert:
         that:

--- a/tests/integration/targets/filter_decrypt/tasks/main.yml
+++ b/tests/integration/targets/filter_decrypt/tasks/main.yml
@@ -8,14 +8,14 @@
     - name: Test bad parameter detection (1/2)
       set_fact:
         sops_bad_input_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(input_type='foo') }}"
-      ignore_errors: true
       register: sops_bad_input_type
+      failed_when: sops_bad_input_type is not failed
 
     - name: Test bad parameter detection (2/2)
       set_fact:
         sops_bad_output_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(output_type=23) }}"
-      ignore_errors: true
       register: sops_bad_output_type
+      failed_when: sops_bad_output_type is not failed
 
     - assert:
         that:
@@ -29,8 +29,8 @@
     - name: Test decrypt of non-sops file
       set_fact:
         sops_wrong_file: "{{ 'this-is-not: a sops file' | community.sops.decrypt }}"
-      ignore_errors: true
       register: sops_filter_wrong_file
+      failed_when: sops_filter_wrong_file is not failed
 
     - assert:
         that:
@@ -40,8 +40,8 @@
     - name: Test simple filter
       set_fact:
         sops_success: "{{ lookup('file', 'simple.sops.yaml') | community.sops.decrypt }}"
-      ignore_errors: true
       register: sops_filter_simple
+      failed_when: sops_filter_simple is not failed
 
     - assert:
         that:

--- a/tests/integration/targets/load_vars/tasks/main.yml
+++ b/tests/integration/targets/load_vars/tasks/main.yml
@@ -12,7 +12,6 @@
 
     - assert:
         that:
-          - load_vars_missing_option is failed
           - '"missing required arguments: file" in load_vars_missing_option.msg'
 
     - name: Test load_vars with wrong choice value
@@ -24,7 +23,6 @@
 
     - assert:
         that:
-          - load_vars_invalid_value is failed
           - '"value of expressions must be one of: ignore, evaluate-on-load, got: invalid value" in load_vars_invalid_value.msg'
 
     - name: Test load_vars with missing file
@@ -35,7 +33,6 @@
 
     - assert:
         that:
-          - load_vars_missing_file is failed
           - |
             "Could not find or access 'non-existent.sops.yaml'\n" in load_vars_missing_file.msg
 
@@ -47,7 +44,6 @@
 
     - assert:
         that:
-          - load_vars_wrong_file is failed
           - "'sops metadata not found' in load_vars_wrong_file.msg"
 
     - name: Test load_vars with simple file into variable

--- a/tests/integration/targets/load_vars/tasks/main.yml
+++ b/tests/integration/targets/load_vars/tasks/main.yml
@@ -7,8 +7,8 @@
   block:
     - name: Test load_vars with missing option
       community.sops.load_vars:
-      ignore_errors: true
       register: load_vars_missing_option
+      failed_when: load_vars_missing_option is not failed
 
     - assert:
         that:
@@ -19,8 +19,8 @@
       community.sops.load_vars:
         file: a
         expressions: invalid value
-      ignore_errors: true
       register: load_vars_invalid_value
+      failed_when: load_vars_invalid_value is not failed
 
     - assert:
         that:
@@ -30,8 +30,8 @@
     - name: Test load_vars with missing file
       community.sops.load_vars:
         file: non-existent.sops.yaml
-      ignore_errors: true
       register: load_vars_missing_file
+      failed_when: load_vars_missing_file is not failed
 
     - assert:
         that:
@@ -42,8 +42,8 @@
     - name: Test load_vars with non-sops file
       community.sops.load_vars:
         file: wrong.yaml
-      ignore_errors: true
       register: load_vars_wrong_file
+      failed_when: load_vars_wrong_file is not failed
 
     - assert:
         that:

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -9,11 +9,12 @@
     - name: Test lookup with missing file
       set_fact:
         sops_file_does_not_exists: "{{ lookup('community.sops.sops', 'file-does-not-exists.sops.yml') }}"
+      ignore_errors: true
       register: sops_lookup_missing_file
-      failed_when: sops_lookup_missing_file is not failed
 
     - assert:
         that:
+          - "sops_lookup_missing_file is failed"
           - "'could not locate file in lookup: file-does-not-exists.sops.yml' in sops_lookup_missing_file.msg"
 
     - name: Test lookup with missing file with empty_on_not_exist
@@ -29,11 +30,12 @@
     - name: Test lookup of non-sops file
       set_fact:
         sops_wrong_file: "{{ lookup('community.sops.sops', 'wrong.yaml') }}"
+      ignore_errors: true
       register: sops_lookup_wrong_file
-      failed_when: sops_lookup_wrong_file is not failed
 
     - assert:
         that:
+          - "sops_lookup_wrong_file is failed"
           - "'sops metadata not found' in sops_lookup_wrong_file.msg"
 
     - name: Test simple lookup
@@ -44,6 +46,7 @@
 
     - assert:
         that:
+          - "sops_lookup_simple is success"
           - "sops_success == 'foo: bar'"
 
     - name: Test rstrip

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -42,7 +42,6 @@
       set_fact:
         sops_success: "{{ lookup('community.sops.sops', 'simple.sops.yaml') }}"
       register: sops_lookup_simple
-      failed_when: sops_lookup_simple is not failed
 
     - assert:
         that:

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -9,8 +9,8 @@
     - name: Test lookup with missing file
       set_fact:
         sops_file_does_not_exists: "{{ lookup('community.sops.sops', 'file-does-not-exists.sops.yml') }}"
-      ignore_errors: true
       register: sops_lookup_missing_file
+      failed_when: sops_lookup_missing_file is not failed
 
     - assert:
         that:
@@ -30,8 +30,8 @@
     - name: Test lookup of non-sops file
       set_fact:
         sops_wrong_file: "{{ lookup('community.sops.sops', 'wrong.yaml') }}"
-      ignore_errors: true
       register: sops_lookup_wrong_file
+      failed_when: sops_lookup_wrong_file is not failed
 
     - assert:
         that:
@@ -41,8 +41,8 @@
     - name: Test simple lookup
       set_fact:
         sops_success: "{{ lookup('community.sops.sops', 'simple.sops.yaml') }}"
-      ignore_errors: true
       register: sops_lookup_simple
+      failed_when: sops_lookup_simple is not failed
 
     - assert:
         that:

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -14,7 +14,6 @@
 
     - assert:
         that:
-          - "sops_lookup_missing_file is failed"
           - "'could not locate file in lookup: file-does-not-exists.sops.yml' in sops_lookup_missing_file.msg"
 
     - name: Test lookup with missing file with empty_on_not_exist
@@ -35,7 +34,6 @@
 
     - assert:
         that:
-          - "sops_lookup_wrong_file is failed"
           - "'sops metadata not found' in sops_lookup_wrong_file.msg"
 
     - name: Test simple lookup
@@ -46,7 +44,6 @@
 
     - assert:
         that:
-          - "sops_lookup_simple is success"
           - "sops_success == 'foo: bar'"
 
     - name: Test rstrip

--- a/tests/integration/targets/setup_sops/tasks/install.yml
+++ b/tests/integration/targets/setup_sops/tasks/install.yml
@@ -25,7 +25,7 @@
 
 - name: Import sops test GPG key on localhost
   command: gpg --import /tmp/sops_functional_tests_key.asc
-  ignore_errors: true
+  failed_when: false
   delegate_to: localhost
 
 # ---------------------------------------------------------------------------
@@ -48,4 +48,4 @@
 
 - name: Import sops test GPG key on remote
   command: gpg --import /tmp/sops_functional_tests_key.asc
-  ignore_errors: true
+  failed_when: false

--- a/tests/integration/targets/setup_sops/tasks/main.yml
+++ b/tests/integration/targets/setup_sops/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: Test whether sops is installed
   command: sops --help
-  ignore_errors: true
+  failed_when: false
   changed_when: false
   register: sops_help_command
 
@@ -18,7 +18,7 @@
   block:
     - name: Test whether age is installed
       command: age --version
-      ignore_errors: true
+      failed_when: false
       changed_when: false
       register: age_version_command
 

--- a/tests/integration/targets/setup_sops/tasks/main.yml
+++ b/tests/integration/targets/setup_sops/tasks/main.yml
@@ -11,10 +11,10 @@
 
 - name: Install sops
   include_tasks: install.yml
-  when: sops_help_command is failed
+  when: sops_help_command.rc != 0
 
 - name: Skip sops installation
-  when: sops_help_command is not failed
+  when: sops_help_command.rc == 0
   block:
     - name: Test whether age is installed
       command: age --version
@@ -25,4 +25,4 @@
     - name: Set results
       set_fact:
         sops_installed: true
-        age_installed: '{{ age_version_command is not failed }}'
+        age_installed: '{{ age_version_command.rc == 0 }}'

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -44,7 +44,6 @@
 
     - assert:
         that:
-          - result_not_base64 is failed
           - '"Cannot decode Base64 encoded data" in result_not_base64.msg'
 
     # Broken file overwrite
@@ -92,8 +91,6 @@
 
     - assert:
         that:
-          - result_cannot_decode_check is failed
-          - result_cannot_decode is failed
           - result_cannot_decode_force_check is changed
           - result_cannot_decode_force is changed
           - value == 'Test'

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -39,8 +39,8 @@
       community.sops.sops_encrypt:
         path: "{{ remote_tmp_dir }}/test_bad_base64"
         content_binary: This is not Base64
-      ignore_errors: true
       register: result_not_base64
+      failed_when: result_not_base64 is not failed
 
     - assert:
         that:
@@ -58,16 +58,16 @@
       community.sops.sops_encrypt:
         path: "{{ remote_tmp_dir }}/broken"
         content_text: Test
-      ignore_errors: true
       register: result_cannot_decode_check
+      failed_when: result_cannot_decode_check is not failed
       check_mode: true
 
     - name: Cannot decode existing file (overwrite)
       community.sops.sops_encrypt:
         path: "{{ remote_tmp_dir }}/broken"
         content_text: Test
-      ignore_errors: true
       register: result_cannot_decode
+      failed_when: result_cannot_decode is not failed
 
     - name: Cannot decode existing file (force, check mode)
       community.sops.sops_encrypt:


### PR DESCRIPTION
~~This should avoid tests that we *expect* to (likely) fail to be reported as "failed" in the GHA summary (see for example https://github.com/ansible-collections/community.sops/actions/runs/5031515902).~~ Seems that only shows up inbetween, not in the final summary :shrug:

Anyway, I think this is cleaner, so let's see how this goes.