### PR TITLE
sops moved from gh.com/mozilla/sops to gh.com/getsops/sops

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ SPDX-License-Identifier: GPL-3.0-or-later
 [![CI](https://github.com/ansible-collections/community.sops/workflows/CI/badge.svg?event=push)](https://github.com/ansible-collections/community.sops/actions) [![Codecov](https://img.shields.io/codecov/c/github/ansible-collections/community.sops)](https://codecov.io/gh/ansible-collections/community.sops)
 
 <!-- Describe the collection and why a user would want to use it. What does the collection do? -->
-The `community.sops` collection allows integrating [`mozilla/sops`](https://github.com/mozilla/sops) in Ansible.
+The `community.sops` collection allows integrating [`getsops/sops`](https://github.com/getsops/sops) in Ansible.
 
-`mozilla/sops` is a tool for encryption and decryption of files using secure keys (GPG, KMS). It can be leveraged in Ansible to provide an easy to use and flexible to manage way to manage ecrypted secrets' files.
+`getsops/sops` is a tool for encryption and decryption of files using secure keys (GPG, KMS). It can be leveraged in Ansible to provide an easy to use and flexible to manage way to manage ecrypted secrets' files.
 
 Please note that this collection does **not** support Windows targets.
 
@@ -18,7 +18,7 @@ Please note that this collection does **not** support Windows targets.
 
 The following table shows which versions of sops were tested with which versions of the collection. Older (or newer) versions of sops can still work fine, it just means that we did not test them. In some cases, it could be that a minimal required version of sops is explicitly documented for a specific feature. Right now, that is not the case.
 
-|`community.sops` version|`mozilla/sops` version|
+|`community.sops` version|`getsops/sops` version|
 |---|---|
 |0.1.0|`3.5.0+`|
 |1.0.6|`3.5.0+`|
@@ -34,7 +34,7 @@ The vars plugin requires ansible-base 2.10 or later.
 
 <!-- List any external resources the collection depends on, for example minimum versions of an OS, libraries, or utilities. Do not list other Ansible collections here. -->
 
-You will need to install [`sops`](https://github.com/mozilla/sops) manually before using plugins provided by this
+You will need to install [`sops`](https://github.com/getsops/sops) manually before using plugins provided by this
 collection.
 
 ## Collection Documentation

--- a/changelogs/fragments/151-github.yml
+++ b/changelogs/fragments/151-github.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "install role - fix ``sops_github_latest_detection=latest-release``, which broke due to sops moving to another GitHub organization (https://github.com/ansible-collections/community.sops/pull/151)."

--- a/docs/docsite/rst/guide.rst
+++ b/docs/docsite/rst/guide.rst
@@ -8,7 +8,7 @@
 Protecting Ansible secrets with Mozilla SOPS
 ============================================
 
-`Mozilla SOPS <https://github.com/mozilla/sops>`_ allows to encrypt and decrypt files using various key sources (GPG, AWS KMS, GCP KMS, ...). For structured data, such as YAML, JSON, INI and ENV files, it will encrypt values, but not mapping keys. For YAML files, it also encrypts comments. This makes it a great tool for encrypting credentials with Ansible: you can easily see which files contain which variable, but the variables themselves are encrypted.
+`Mozilla SOPS <https://github.com/getsops/sops>`_ allows to encrypt and decrypt files using various key sources (GPG, AWS KMS, GCP KMS, ...). For structured data, such as YAML, JSON, INI and ENV files, it will encrypt values, but not mapping keys. For YAML files, it also encrypts comments. This makes it a great tool for encrypting credentials with Ansible: you can easily see which files contain which variable, but the variables themselves are encrypted.
 
 The ability to utilize various keysources makes it easier to use in complex environments than `Ansible Vault <https://docs.ansible.com/ansible/latest/user_guide/vault.html>`_.
 
@@ -19,7 +19,7 @@ The ability to utilize various keysources makes it easier to use in complex envi
 Installing sops
 ---------------
 
-You can find binaries and packages `on the project's release page <https://github.com/mozilla/sops/releases>`_. Depending on your operating system, you might also be able to install it with your system's package manager.
+You can find binaries and packages `on the project's release page <https://github.com/getsops/sops/releases>`_. Depending on your operating system, you might also be able to install it with your system's package manager.
 
 This collection provides a `role community.sops.install <ansible_collections.community.sops.install_role>`_ which allows to install sops and `GNU Privacy Guard (GPG) <https://en.wikipedia.org/wiki/GNU_Privacy_Guard>`__. The role allows to install sops from the system's package manager or from GitHub. Both sops and GPG can be installed on the remote hosts or the Ansible controller.
 
@@ -300,7 +300,7 @@ For example, assume that you want to decrypt a file retrieved from a HTTPS serve
       tasks:
         - name: Fetch file from URL
           ansible.builtin.uri:
-            url: https://raw.githubusercontent.com/mozilla/sops/master/functional-tests/res/comments.enc.yaml
+            url: https://raw.githubusercontent.com/getsops/sops/master/functional-tests/res/comments.enc.yaml
             return_content: true
           register: encrypted_content
 
@@ -376,7 +376,7 @@ Please note that if you put a Jinja2 expression in a variable, it will be evalua
       tasks:
         - name: Fetch file from URL
           ansible.builtin.uri:
-            url: https://raw.githubusercontent.com/mozilla/sops/master/functional-tests/res/comments.enc.yaml
+            url: https://raw.githubusercontent.com/getsops/sops/master/functional-tests/res/comments.enc.yaml
             return_content: true
           register: encrypted_content
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,7 +9,7 @@ version: 1.6.3
 readme: README.md
 authors:
   - Edoardo Tenani
-description: "Support usage of mozilla/sops from your Ansible playbooks"
+description: "Support usage of getsops/sops from your Ansible playbooks"
 license:
   - GPL-3.0-or-later
   - BSD-2-Clause

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -80,7 +80,7 @@ EXAMPLES = '''
   tasks:
     - name: Fetch file from URL
       ansible.builtin.uri:
-        url: https://raw.githubusercontent.com/mozilla/sops/master/functional-tests/res/comments.enc.yaml
+        url: https://raw.githubusercontent.com/getsops/sops/master/functional-tests/res/comments.enc.yaml
         return_content: true
       register: encrypted_content
 

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -14,7 +14,7 @@ from ansible.module_utils.common.text.converters import to_text, to_native
 from subprocess import Popen, PIPE
 
 
-# From https://github.com/mozilla/sops/blob/master/cmd/sops/codes/codes.go
+# From https://github.com/getsops/sops/blob/master/cmd/sops/codes/codes.go
 # Should be manually updated
 SOPS_ERROR_CODES = {
     1: "ErrorGeneric",

--- a/roles/install/meta/argument_specs.yml
+++ b/roles/install/meta/argument_specs.yml
@@ -8,7 +8,7 @@ argument_specs:
     short_description: Install Mozilla sops
     version_added: 1.5.0
     description:
-      - This role installs L(Mozilla sops,https://github.com/mozilla/sops) and Gnu Privacy Guard (GPG).
+      - This role installs L(Mozilla sops,https://github.com/getsops/sops) and Gnu Privacy Guard (GPG).
       - >-
         This role supports the following operating systems:
         Alpine (new enough),
@@ -33,7 +33,7 @@ argument_specs:
         default: auto
         description:
           - Determines the source from where sops is installed.
-          - The value C(github) will install sops from the Mozilla sops releases on GitHub (U(https://github.com/mozilla/sops/releases/)).
+          - The value C(github) will install sops from the Mozilla sops releases on GitHub (U(https://github.com/getsops/sops/releases/)).
           - The value C(system) will install sops from the system packages. Note that not all system package repositories support sops.
           - The value C(auto) will determine the best source to install sops from. Here, system package repositories are preferred over GitHub.
         type: str

--- a/roles/install/meta/main.yml
+++ b/roles/install/meta/main.yml
@@ -6,6 +6,6 @@
 galaxy_info:
   standalone: false
   description: >
-    Install Mozilla sops (https://github.com/mozilla/sops).
+    Install Mozilla sops (https://github.com/getsops/sops).
 
 dependencies: []

--- a/roles/install/tasks/github_api.yml
+++ b/roles/install/tasks/github_api.yml
@@ -11,7 +11,7 @@
     status_code:
       - 200
       - 403  # "HTTP Error 403: rate limit exceeded"
-    url: https://api.github.com/repos/mozilla/sops/releases
+    url: https://api.github.com/repos/getsops/sops/releases
   register: _community_sops_install_github_releases
   delegate_to: localhost
   run_once: true

--- a/roles/install/tasks/github_latest_release.yml
+++ b/roles/install/tasks/github_latest_release.yml
@@ -9,7 +9,7 @@
     status_code:
       - 302
       - 307
-    url: https://github.com/mozilla/sops/releases/latest/
+    url: https://github.com/getsops/sops/releases/latest/
   register: _community_sops_install_github_latest_release
   delegate_to: localhost
   run_once: true
@@ -28,7 +28,7 @@
 - name: In case this failed, inform user
   ansible.builtin.debug:
     msg: >-
-      Could not obtain latest version from https://github.com/mozilla/sops/releases/latest/.
+      Could not obtain latest version from https://github.com/getsops/sops/releases/latest/.
       Please create an issue in https://github.com/ansible-collections/community.sops/issues/
       if there is not already one.
   when: _community_sops_install_effective_sops_version == ''

--- a/roles/install/vars/OS-Debian.yml
+++ b/roles/install/vars/OS-Debian.yml
@@ -16,7 +16,7 @@ _community_sops_install_system_packages_unsigned: []
 _community_sops_install_arch_transform:
   x86_64: amd64
 _community_sops_install_system_package_deb_github: >-
-  https://github.com/mozilla/sops/releases/download/v{{
+  https://github.com/getsops/sops/releases/download/v{{
     _community_sops_install_effective_sops_version
   }}/sops_{{
     _community_sops_install_effective_sops_version

--- a/roles/install/vars/OS-RedHat.yml
+++ b/roles/install/vars/OS-RedHat.yml
@@ -17,7 +17,7 @@ _community_sops_install_system_package_deb_github: false
 _community_sops_install_system_packages_github: []
 _community_sops_install_system_packages_unsigned_github:
   - >-
-    https://github.com/mozilla/sops/releases/download/v{{
+    https://github.com/getsops/sops/releases/download/v{{
       _community_sops_install_effective_sops_version
     }}/sops-{{
       (_community_sops_install_effective_sops_version is version('3.6.0', '<')) | ternary('v', '')

--- a/tests/ee/all.yml
+++ b/tests/ee/all.yml
@@ -7,7 +7,7 @@
   tasks:
     - name: Download sops test GPG key on localhost
       get_url:
-        url: https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc
+        url: https://raw.githubusercontent.com/getsops/sops/master/pgp/sops_functional_tests_key.asc
         dest: /tmp/sops_functional_tests_key.asc
     - name: Import sops test GPG key on localhost
       command: gpg --import /tmp/sops_functional_tests_key.asc

--- a/tests/integration/targets/setup_sops/tasks/install.yml
+++ b/tests/integration/targets/setup_sops/tasks/install.yml
@@ -19,7 +19,7 @@
 
 - name: Download sops test GPG key on localhost
   get_url:
-    url: https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc
+    url: https://raw.githubusercontent.com/getsops/sops/master/pgp/sops_functional_tests_key.asc
     dest: /tmp/sops_functional_tests_key.asc
   delegate_to: localhost
 
@@ -43,7 +43,7 @@
 
 - name: Download sops test GPG key on remote
   get_url:
-    url: https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc
+    url: https://raw.githubusercontent.com/getsops/sops/master/pgp/sops_functional_tests_key.asc
     dest: /tmp/sops_functional_tests_key.asc
 
 - name: Import sops test GPG key on remote

--- a/tests/integration/targets/var_sops/README.md
+++ b/tests/integration/targets/var_sops/README.md
@@ -23,4 +23,4 @@ If possible, extend an existing test. If that's not possible, or if you are afra
 2. Create a `playbook.yml` and `validate.sh` in there (copy from a similar test and adjust);
 3. Create subdirectories `group_vars` and/or `host_vars` and fill them as needed.
 
-For creating sops encrypted files, use the private GPG keys from https://raw.githubusercontent.com/mozilla/sops/master/pgp/sops_functional_tests_key.asc. There is a `.sops.yaml` file in this directory which makes sure that sops automatically uses the correct one of the keys provided in that file.
+For creating sops encrypted files, use the private GPG keys from https://raw.githubusercontent.com/getsops/sops/master/pgp/sops_functional_tests_key.asc. There is a `.sops.yaml` file in this directory which makes sure that sops automatically uses the correct one of the keys provided in that file.


### PR DESCRIPTION
This breaks the installation role in some cases. This PR fixes the installation role and updates all references to the new GH organization.