### PR TITLE
Disable EE with ansible-core devel for now until UBI 9 has Python 3.10 support

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -117,7 +117,7 @@ jobs:
             docker_container: quay.io/ansible-community/test-image:debian-bookworm
             python_version: '3.11'
             sops_version: latest
-          - ansible: devel
+          - ansible: stable-2.15
             docker_container: quay.io/ansible-community/test-image:debian-bullseye
             python_version: '3.9'
             sops_version: latest

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -195,7 +195,7 @@ jobs:
             # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
             pre-test-cmd: |-
               git clone --depth=1 --single-branch https://github.com/ansible-collections/community.general.git ../../community/general
-          - ansible: devel
+          - ansible: stable-2.15
             docker_container: quay.io/ansible-community/test-image:centos-stream8
             python_version: '3.9'
             target: gha/install/3/
@@ -205,7 +205,7 @@ jobs:
             python_version: '3.11'
             target: gha/install/3/
             github_latest_detection: auto
-          - ansible: devel
+          - ansible: stable-2.15
             docker_container: quay.io/ansible-community/test-image:debian-bullseye
             python_version: '3.9'
             target: gha/install/3/

--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -45,12 +45,12 @@ jobs:
         exclude:
           - ansible_core: ''
         include:
-          - name: ansible-core devel @ RHEL UBI 9
-            ansible_core: https://github.com/ansible/ansible/archive/devel.tar.gz
-            ansible_runner: ansible-runner
-            base_image: docker.io/redhat/ubi9:latest
-            pre_base: '"#"'
-            execute_playbook: ansible-playbook -v community.sops.install_localhost
+          # - name: ansible-core devel @ RHEL UBI 9
+          #   ansible_core: https://github.com/ansible/ansible/archive/devel.tar.gz
+          #   ansible_runner: ansible-runner
+          #   base_image: docker.io/redhat/ubi9:latest
+          #   pre_base: '"#"'
+          #   execute_playbook: ansible-playbook -v community.sops.install_localhost
           - name: ansible-core 2.15 @ Rocky Linux 9
             ansible_core: https://github.com/ansible/ansible/archive/stable-2.15.tar.gz
             ansible_runner: ansible-runner


### PR DESCRIPTION
##### SUMMARY
ansible-core devel now needs Python 3.10+, but the RHEL UBI 9 does not have Python 3.10 support yet apparently.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
EE CI
