### PR TITLE
Support lookup of a specific key in a SOPS file

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,40 @@ tasks:
     no_log: true  # avoid content to be written to log
 ```
 
+You can also optionally fetch a specific key from a SOPS file and even load its own keys if it's a dict.
+
+Assuming the SOPS file looks like this:
+
+```yaml
+specific_key_in_sops_file:
+   foo:
+     bar: something
+
+another_key:
+   boo:
+     hello: world
+```
+
+Then this:
+
+```yaml
+tasks:
+  - name: Test community.sops integration
+    ansible.builtin.debug:
+        msg: >
+          {{ lookup('community.sops.sops', playbook_dir + '/../vars/sops/my-secret-file.sops.yml', key='specific_key_in_sops_file') }}
+```
+
+Should return this:
+
+```json
+    "msg": {
+        "foo": {
+            "bar": "something"
+        }
+    }
+```
+
 See [Lookup Plugins](https://docs.ansible.com/ansible/latest/plugins/lookup.html) for more details on lookup plugins.
 
 ### filter plugin

--- a/tests/integration/targets/lookup_sops/files/key.sops.yaml
+++ b/tests/integration/targets/lookup_sops/files/key.sops.yaml
@@ -1,0 +1,32 @@
+test:
+    foo:
+        bar: ENC[AES256_GCM,data:8QqkYYTPFNkdbQ4=,iv:kbI184B2ymLiul1PE0iraaBkK2O1vRRJKJLIQUhbBWY=,tag:N1zLCoi1QnGctFhP4zRQ6Q==,type:str]
+another:
+    should:
+        not: ENC[AES256_GCM,data:Y42t2j/n,iv:oZkeaWuT7EADUEuc5V7jNAHCRBXQXf5wpOkgnA7rN6o=,tag:8aDDSlGqBiaSytVZRbr8Xg==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2023-08-22T01:11:07Z"
+    mac: ENC[AES256_GCM,data:8tu7O51Cim0z9Arhj4GiyL8nkQreLCB6qy7yYxa4NJ73HuVNpkYUwQJ66BF9Dg3/QrLoyaBus5gN9kLW9JvMFeRXFKj0oEMJBmatobqfFghlPnmrPhNbaq7h2kmg6kxnErp7LLKMkSD+6r9i0LWtBSTm2c454oWgM7OIgsYY++g=,iv:h+0hVBx7zpQD0RqlJCDYXU67F2GoWqexYyR5hqBN6m8=,tag:+TIsefK7e82/t8K9L2mQ+w==,type:str]
+    pgp:
+        - created_at: "2023-08-22T00:27:53Z"
+          enc: |
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMAyUpShfNkFB/AQgApPkM5OBHHh+7xh+MJTxYnGedNgU9utXs1oFaLRew/X2m
+            7BDgzMk2toepFzPEkip3d89qXImsmFwUblniIeH7Hrc2oAPuBoLIsfx+b9ZcQ8iW
+            fbiHb3hfTYxv54FwflP8dXJ1h2PQfIkK4yxuEdgfJNu6JQAYaJAAHb0iLjUJTvh+
+            KFhI0JtMwxsCoUchmdqFLfqPSYH/HKqfPb7oFLtuj3YzV20/wIesMWQG2pvja8b2
+            hnqNkaYt4iWo55Wtq8X/dKsBqz64o5wTvFLsrKA3qa4Da8DZs+shWEjf6q0kBRxu
+            VzorYDQ3ysjSX1trRamClXM3RSvdXRslzWkKTMCr7dJeAfJhn6gSCn5ctfkLI6nl
+            u/c0P2FvfF3ua56dmIi78MzafErQs5xEnYFHdl6aJBFFCPq+vVfxVG9hZbVdLk1d
+            2xW8Sq6o5uD5Xn8r70LOCN3xZZEzrooM0ALzrpnEbw==
+            =wr3v
+            -----END PGP MESSAGE-----
+          fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.7.1

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -48,6 +48,17 @@
           - "sops_lookup_simple is success"
           - "sops_success == 'foo: bar'"
 
+    - name: Test key lookup
+      set_fact:
+        sops_success: "{{ lookup('community.sops.sops', 'key.sops.yaml', key='test') }}"
+      register: sops_lookup_key
+
+    - assert:
+        that:
+          - "sops_lookup_key is success"
+          - "sops_success['foo']['bar'] == 'hello world'"
+          - "'another' not in sops_success"
+
     - name: Test rstrip
       set_fact:
         with_rstrip: "{{ lookup('community.sops.sops', 'rstrip.sops', rstrip=true) }}"


### PR DESCRIPTION
### Motivation

I have a use case for looking up a specific key from a SOPS file. Often, said structure is not a simple `key: value` but a more complex dict from which I need to obtain the values of sub-keys in the dict.

Right now with the community SOPS collection, a SOPS file containing a dict comes back as a string with `\n` line breaks and I am having to resort to a custom lookup plugin to do what I want. This PR achieves it for the community collection, so thought I'd offer it, but it may not be solid enough to work for wider cases - feel free to discard it.

### Changes description

An optional `key` argument can be passed to the lookup plugin. If that key is found in the SOPS file, it's that item that gets appended and returned.

See the test suite and the README example for more information on how to use it.

### Additional notes

I only tested it with YAML SOPS files, and I didn't test it with multiple SOPS files passed in as terms. The tests were all passing at time of writing.