### PR TITLE
Test with 3.8.0-rc1, fix install role to handle 3.8.0-rc1 correctly and avoid prereleases if asked for the latest version

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -74,6 +74,7 @@ jobs:
           - 3.5.0
           - 3.6.0
           - 3.7.3
+          - 3.8.0-rc.1
         python_version:
           - ''
         include:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following table shows which versions of sops were tested with which versions
 |---|---|
 |0.1.0|`3.5.0+`|
 |1.0.6|`3.5.0+`|
-|`main` branch|`3.5.0`, `3.6.0`, `3.7.1`, `3.7.2`, `3.7.3`|
+|`main` branch|`3.5.0`, `3.6.0`, `3.7.1`, `3.7.2`, `3.7.3`, `3.8.0-rc.1`|
 
 ## Tested with Ansible
 

--- a/changelogs/fragments/159-new-releases.yml
+++ b/changelogs/fragments/159-new-releases.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "Avoid pre-releases when picking the latest version when using the GitHub API method (https://github.com/ansible-collections/community.sops/pull/159)."
+  - "Fix changed DEB and RPM URLs for 3.8.0 and its prerelease(s) (https://github.com/ansible-collections/community.sops/pull/159)."

--- a/plugins/filter/_latest_version.py
+++ b/plugins/filter/_latest_version.py
@@ -64,7 +64,12 @@ def pick_latest_version(version_list):
     '''Pick latest version from a list of versions.'''
     if not version_list:
         return ''
-    return sorted(version_list, key=LooseVersion, reverse=True)[0]
+    return sorted(
+        # Remove all prereleases (versions with '+' or '-' in them)
+        [v for v in version_list if '-' not in v and '+' not in v],
+        key=LooseVersion,
+        reverse=True,
+    )[0]
 
 
 class FilterModule(object):

--- a/roles/install/meta/argument_specs.yml
+++ b/roles/install/meta/argument_specs.yml
@@ -55,7 +55,7 @@ argument_specs:
         description:
           - When installing the latest sops version from GitHub, configures how the latest release is detected.
           - V(auto) tries V(api) first and then uses V(latest-release).
-          - V(api) asks the GitHub API for a list of recent releases and picks the highest version.
+          - V(api) asks the GitHub API for a list of recent releases and picks the highest version. Pre-releases are avoided.
           - V(latest-release) uses a not fully documented URL to retrieve the release marked as "latest" by the repository maintainers.
         type: str
         choices:

--- a/roles/install/vars/OS-Debian.yml
+++ b/roles/install/vars/OS-Debian.yml
@@ -19,7 +19,7 @@ _community_sops_install_system_package_deb_github: >-
   https://github.com/getsops/sops/releases/download/v{{
     _community_sops_install_effective_sops_version
   }}/sops_{{
-    _community_sops_install_effective_sops_version
+    _community_sops_install_effective_sops_version.replace('-', '.')
   }}_{{
     _community_sops_install_arch_transform.get(ansible_facts.architecture, ansible_facts.architecture)
   }}.deb

--- a/roles/install/vars/OS-RedHat.yml
+++ b/roles/install/vars/OS-RedHat.yml
@@ -22,8 +22,10 @@ _community_sops_install_system_packages_unsigned_github:
     }}/sops-{{
       (_community_sops_install_effective_sops_version is version('3.6.0', '<')) | ternary('v', '')
     }}{{
-      _community_sops_install_effective_sops_version
-    }}-1.{{
+      _community_sops_install_effective_sops_version.replace('-', '.')
+    }}{{
+      (_community_sops_install_effective_sops_version is version('3.8.0-a', '<')) | ternary('-1', '')
+    }}.{{
       ansible_facts.architecture
     }}.rpm
 

--- a/tests/integration/targets/filter__latest_version/aliases
+++ b/tests/integration/targets/filter__latest_version/aliases
@@ -1,0 +1,9 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+gha/main
+skip/aix
+skip/osx
+skip/freebsd
+skip/python2.6  # lookups are controller only, and we no longer support Python 2.6 on the controller

--- a/tests/integration/targets/filter__latest_version/tasks/main.yml
+++ b/tests/integration/targets/filter__latest_version/tasks/main.yml
@@ -1,0 +1,33 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- name: Test _latest_version filter
+  ansible.builtin.assert:
+    that:
+      - list_0 | community.sops._latest_version == '1.0.0'
+      - list_1 | community.sops._latest_version == '1.2.1'
+      - list_2 | community.sops._latest_version == '1.2.1'
+      - list_3 | community.sops._latest_version == '1.2.3'
+  vars:
+    list_0:
+      - '1'
+      - '1.0'
+      - 1.0.0
+    list_1:
+      - '1.0'
+      - 1.2.1
+      - 1.0.0
+    list_2:
+      - '1.0'
+      - 1.2.1
+      - 1.2.1-rc.1
+      - 1.0.0
+    list_3:
+      - '1.0'
+      - 1.2.3
+      - 1.4.0-rc.1
+      - 1.4.0-a1+5
+      - 1.4.0+5
+      - 1.0.0


### PR DESCRIPTION
https://github.com/getsops/sops/releases/tag/v3.8.0-rc.1