### PR TITLE
Use yaml output on .yml files too

### DIFF
--- a/changelogs/fragments/165-yaml-output-for-yml-extension.yaml
+++ b/changelogs/fragments/165-yaml-output-for-yml-extension.yaml
@@ -1,3 +1,2 @@
-
 bugfixes:
-  - sops_encrypt - fix output-type not set to ``yaml`` when file ended with ``.yml``. Now both ``.yaml`` and ``.yml`` files use the SOPS ``--output-type=yaml`` formatting. (https://github.com/ansible-collections/community.sops/issues/164).
+  - sops_encrypt - ensure that output-type is set to ``yaml`` when the file extension ``.yml`` is used. Now both ``.yaml`` and ``.yml`` files use the SOPS ``--output-type=yaml`` formatting (https://github.com/ansible-collections/community.sops/issues/164).

--- a/changelogs/fragments/165-yaml-output-for-yml-extension.yaml
+++ b/changelogs/fragments/165-yaml-output-for-yml-extension.yaml
@@ -1,0 +1,3 @@
+
+bugfixes:
+  - sops_encrypt - fix output-type not set to ``yaml`` when file ended with ``.yml``. Now both ``.yaml`` and ``.yml`` files use the SOPS ``--output-type=yaml`` formatting. (https://github.com/ansible-collections/community.sops/issues/164).

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -216,7 +216,7 @@ def main():
             output_type = None
             if path.endswith('.json'):
                 output_type = 'json'
-            elif path.endswith('.yaml'):
+            elif path.endswith('.yaml') or path.endswith('.yml'):
                 output_type = 'yaml'
             data = Sops.encrypt(
                 data=input_data, cwd=directory, input_type=input_type, output_type=output_type,


### PR DESCRIPTION
### Motivation
<!-- describe why this changes are necessary/useful -->
Closes #164

### Changes description
<!-- describe what changes are in this PR. Overview is OK, details shall be found in the git commits -->
- Changed `sops_encrypt` module to also use `yaml` output on `.yml` files

### Additional notes
<!-- any note related to these changes, please add them here -->
