### PR TITLE
CI: make sure that Arch images are updated first

### DIFF
--- a/tests/integration/targets/role_install_latest/meta/main.yml
+++ b/tests/integration/targets/role_install_latest/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_pkg_mgr

--- a/tests/integration/targets/role_install_localhost_remote/meta/main.yml
+++ b/tests/integration/targets/role_install_localhost_remote/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_pkg_mgr

--- a/tests/integration/targets/role_install_version/meta/main.yml
+++ b/tests/integration/targets/role_install_version/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_pkg_mgr

--- a/tests/integration/targets/setup_pkg_mgr/tasks/archlinux.yml
+++ b/tests/integration/targets/setup_pkg_mgr/tasks/archlinux.yml
@@ -1,0 +1,28 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Since Arch Linux is a rolling distribution, it regularly needs its packages upgraded, otherwise some tests might
+# stop working due to conflicts during package installation. Since there is no good way to do this on container
+# startup time, we use the setup_pkg_mgr setup role to do this once per CI run (hopefully). In case the Arch Linux
+# tests are run outside of a container, we're using a date-based tag (see below) to avoid this running more than
+# once per day.
+
+- name: Create tag
+  copy:
+    dest: /tmp/.ansible_archlinux_sysupgrade_tag
+    content: |
+      Last ArchLinux system upgrade by integration tests was done on {{ ansible_facts.date_time.date }}.
+  register: archlinux_upgrade_tag
+
+- name: Upgrade all packages
+  pacman:
+    update_cache: true
+    upgrade: true
+  when: archlinux_upgrade_tag is changed
+
+- name: Remove EXTERNALLY-MANAGED file
+  file:
+    path: /usr/lib/python{{ ansible_python.version.major }}.{{ ansible_python.version.minor }}/EXTERNALLY-MANAGED
+    state: absent

--- a/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
+++ b/tests/integration/targets/setup_pkg_mgr/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- when: ansible_os_family == "Archlinux"
+  block:
+    - name: ArchLinux specific setup
+      include_tasks: archlinux.yml

--- a/tests/integration/targets/setup_sops/meta/main.yml
+++ b/tests/integration/targets/setup_sops/meta/main.yml
@@ -1,0 +1,7 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+dependencies:
+  - setup_pkg_mgr


### PR DESCRIPTION
Hopefully fixes nightly CI failures (https://github.com/ansible-collections/community.sops/actions/runs/6609135034). These most likely stem from Arch upgrading sops to 3.8.1, while the Arch Docker image is from 23 hours ago when sops still was at 3.8.0.