### PR TITLE
Add stable-2.17 to CI; copy 2.17 ignore.txt files to 2.18

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -34,6 +34,7 @@ jobs:
           - stable-2.14
           - stable-2.15
           - stable-2.16
+          - stable-2.17
           - devel
     # Ansible-test on various stable branches does not yet work well with cgroups v2.
     # Since ubuntu-latest now uses Ubuntu 22.04, we need to fall back to the ubuntu-20.04
@@ -118,6 +119,10 @@ jobs:
             docker_container: quay.io/ansible-community/test-image:centos-stream8
             python_version: '3.6'
             sops_version: latest
+          # 2.17
+          - ansible: stable-2.17
+            docker_container: ubuntu2204
+            sops_version: 3.8.1
           # devel
           - ansible: devel
             docker_container: quay.io/ansible-community/test-image:archlinux

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The following table shows which versions of sops were tested with which versions
 
 ## Tested with Ansible
 
-Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, and ansible-core 2.16 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
+Tested with the current Ansible 2.9, ansible-base 2.10, ansible-core 2.11, ansible-core 2.12, ansible-core 2.13, ansible-core 2.14, ansible-core 2.15, ansible-core 2.16, and ansible-core 2.17 releases and the current development version of ansible-core. Ansible versions before 2.9.10 are not supported.
 
 The vars plugin requires ansible-base 2.10 or later.
 

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,4 @@
+tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
+tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
+tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error
+tests/integration/targets/lookup_sops/files/hidden-json.yaml yamllint:error

--- a/tests/sanity/ignore-2.18.txt.license
+++ b/tests/sanity/ignore-2.18.txt.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project


### PR DESCRIPTION
##### SUMMARY
Ref: https://forum.ansible.com/t/ansible-core-devel-bumped-to-2-18-0-dev0-stable-2-17-branch-created/4695

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
