### PR TITLE
Stop building EE and testing with CentOS Stream 8, which no longer has builds

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -116,10 +116,6 @@ jobs:
           - ansible: stable-2.16
             docker_container: ubuntu2204
             sops_version: 3.8.0
-          - ansible: stable-2.16
-            docker_container: quay.io/ansible-community/test-image:centos-stream8
-            python_version: '3.6'
-            sops_version: latest
           # 2.17
           - ansible: stable-2.17
             docker_container: ubuntu2204
@@ -212,11 +208,6 @@ jobs:
             # NOTE: we're installing with git to work around Galaxy being a huge PITA (https://github.com/ansible/galaxy/issues/2429)
             pre-test-cmd: |-
               git clone --depth=1 --single-branch https://github.com/ansible-collections/community.general.git ../../community/general
-          - ansible: stable-2.15
-            docker_container: quay.io/ansible-community/test-image:centos-stream8
-            python_version: '3.9'
-            target: gha/install/3/
-            github_latest_detection: auto
           - ansible: devel
             docker_container: quay.io/ansible-community/test-image:debian-bookworm
             python_version: '3.11'

--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -82,15 +82,6 @@ jobs:
             base_image: registry.fedoraproject.org/fedora:38
             pre_base: '"#"'
             execute_playbook: ansible-playbook -v community.sops.install_localhost
-          - name: Ansible 2.9 @ CentOS Stream 8
-            ansible_core: https://github.com/ansible/ansible/archive/stable-2.9.tar.gz
-            ansible_runner: ansible-runner
-            other_deps: |2
-                python_interpreter:
-                  package_system: python39 python39-pip python39-wheel python39-cryptography
-            base_image: quay.io/centos/centos:stream8
-            pre_base: '"#"'
-            execute_playbook: ansible localhost -m include_role -a name=community.sops.install -e sops_install_on_localhost=true -e ansible_python_interpreter=/usr/libexec/platform-python
     runs-on: ubuntu-latest
     steps:
       - name: Check out code


### PR DESCRIPTION
##### SUMMARY
According to https://www.centos.org/download/ "CentOS Stream 8 end of builds is May 31, 2024", so the build seems dead as we can no longer install things. So let's remove it.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
EE tests
integration tests
