### PR TITLE
vars plugin: make valid_extensions configurable

### DIFF
--- a/changelogs/fragments/185-vars-valid-extensions.yml
+++ b/changelogs/fragments/185-vars-valid-extensions.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "sops vars plugin - allow to configure the valid extensions with an ``ansible.cfg`` entry or with an environment variable (https://github.com/ansible-collections/community.sops/pull/185)."

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -13,16 +13,19 @@ DOCUMENTATION = '''
     short_description: Loading sops-encrypted vars files
     version_added: '0.1.0'
     description:
-        - Load encrypted YAML files into corresponding groups/hosts in group_vars/ and host_vars/ directories.
-        - Files are encrypted prior to reading, making this plugin an effective companion to host_group_vars plugin.
-        - Files are restricted to .sops.yaml, .sops.yml, .sops.json extensions.
+        - Load encrypted YAML files into corresponding groups/hosts in C(group_vars/) and C(host_vars/) directories.
+        - Files are encrypted prior to reading, making this plugin an effective companion to P(ansible.builtin.host_group_vars#vars) plugin.
+        - Files are restricted to V(.sops.yaml), V(.sops.yml), V(.sops.json) extensions, unless configured otherwise
+          with O(_valid_extensions).
         - Hidden files are ignored.
     options:
       _valid_extensions:
         default: [".sops.yml", ".sops.yaml", ".sops.json"]
         description:
-          - "Check all of these extensions when looking for 'variable' files which should be YAML or JSON or vaulted versions of these."
-          - 'This affects vars_files, include_vars, inventory and vars plugins among others.'
+          - Check all of these extensions when looking for 'variable' files.
+          - These files must be SOPS encrypted YAML or JSON files.
+            The plugin will produce errors when encountering files matching these extensions that are not SOPS encrypted.
+            (This might change in a future version.)
         type: list
         elements: string
         ini:

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -25,6 +25,13 @@ DOCUMENTATION = '''
           - 'This affects vars_files, include_vars, inventory and vars plugins among others.'
         type: list
         elements: string
+        ini:
+          - key: valid_extensions
+            section: community.sops
+            version_added: 1.7.0
+        env:
+          - name: ANSIBLE_VARS_SOPS_PLUGIN_VALID_EXTENSIONS
+            version_added: 1.7.0
       stage:
         version_added: 0.2.0
         ini:
@@ -88,7 +95,6 @@ display = Display()
 
 FOUND = {}
 DECRYPTED = {}
-DEFAULT_VALID_EXTENSIONS = [".sops.yaml", ".sops.yml", ".sops.json"]
 
 
 class VarsModule(BaseVarsPlugin):
@@ -109,6 +115,8 @@ class VarsModule(BaseVarsPlugin):
 
         if self.get_option('_disable_vars_plugin_temporarily'):
             return {}
+
+        valid_extensions = self.get_option('_valid_extensions')
 
         data = {}
         for entity in entities:
@@ -140,9 +148,9 @@ class VarsModule(BaseVarsPlugin):
                                 # extension.
                                 # See:
                                 # - https://github.com/ansible-collections/community.sops/pull/6
-                                found_files = loader.find_vars_files(opath, entity.name, extensions=DEFAULT_VALID_EXTENSIONS, allow_dir=False)
+                                found_files = loader.find_vars_files(opath, entity.name, extensions=valid_extensions, allow_dir=False)
                                 found_files.extend([file_path for file_path in loader.find_vars_files(opath, entity.name)
-                                                    if any(to_text(file_path).endswith(extension) for extension in DEFAULT_VALID_EXTENSIONS)])
+                                                    if any(to_text(file_path).endswith(extension) for extension in valid_extensions)])
                                 FOUND[key] = found_files
                             else:
                                 self._display.warning("Found %s that is not a directory, skipping: %s" % (subdir, opath))

--- a/tests/integration/targets/vars_sops/test-extensions/group_vars/all.yml
+++ b/tests/integration/targets/vars_sops/test-extensions/group_vars/all.yml
@@ -1,0 +1,30 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+foo: ENC[AES256_GCM,data:a25L,iv:X8ILHZr+YiyLWa90Y+cwoMD1nVuel7JyTs0A5+oiOOo=,tag:GbBtp+Yqx1KEjdyztqS4EQ==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2020-02-20T10:44:32Z'
+    mac: ENC[AES256_GCM,data:BAwQqD9sHgHkmlxPQLKq28Xy48qPp1B/+GDLEsIxir6WNhZgw8OgjVF1u/wCAad6qHkmN02Bwenr+aay6uKfCuOEsTRSvZ7v80yAU+h0wL3zJ/KMkRsE3QP3CWxcLQxInt+YaBjR+Q0IUjDXKm3u6ZomixZe5F5pwWr36ErV6Y0=,iv:e/iiyXQiCh8C2w/bc8mr/Psv+ehmqEMqEC1/bbGFHpY=,tag:NSDo2HISIBJhYvsqrU0mSA==,type:str]
+    pgp:
+      - created_at: '2020-02-20T10:44:32Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgALJTUwdx6rAPckJ+reP5TEq+lXzHI1Zi7aHYOqZQBnA2s
+            z8h1gRce/fn7RPkmdsjsdSYmxGGKqwDXxUYsbN1aWXk6mb4Juktdvjl/GndF6PkU
+            TiN/l1GM6upgS+GPxA01NKsGkVmEtKR5NhsNEnE6OzY29+PFLsBX2vO1Zfg7kzBz
+            cDl6PT8fbFTEaFeyuYl9IslIV8yYsj1oHL3CF76RjCP6b18NSOHM23ytlH+KVaBV
+            ntoSVkTyWDx5o9iEHBEWSEGNpaCWWiEgkDEkA1VqMHdUlsW+IjZ8ggg5NJbcVtrG
+            YkN8rlGsNEzx+g4O4b1160A2K6AdTBcoGHwHD3u3XdLgAeTqT1ekE2N3yNT6w4sm
+            6uET4eTS4Cvg1OFCgOC34uUzlY3gbuVy20h8RNyQoAfhSN4DD2MexKqcMMCVCtn0
+            OhRMTP2jjOCe5Ex3/p3awcVxwx7qeJ26Vnfiwtg6ueFI5AA=
+            =tcnq
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.4.0

--- a/tests/integration/targets/vars_sops/test-extensions/group_vars/all/test.yml
+++ b/tests/integration/targets/vars_sops/test-extensions/group_vars/all/test.yml
@@ -1,0 +1,30 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+bar: ENC[AES256_GCM,data:UGteX9JKWhU=,iv:hgH8BeRf2W4gY4FSyXR/VKR879piGW2MSKJIppFgIJo=,tag:2XKpN3jGGEBBXiJPHi93ew==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    lastmodified: '2020-09-01T16:17:15Z'
+    mac: ENC[AES256_GCM,data:jw/wSpkqwN1Nun1VGLecyJy/yZLtyB57kmoODRhK9/c7nZU8pgTfcATfysyUq0YXWGvpy3mxvlGhaMrHu0DzNCGlsic6OXWDJBPVX3xYeeiUw5KmLxbYPpIXXLYfyu/mWDrToY2o1rpGzJqT7SuZwfFIEX1gZMFnATdROXwVKBU=,iv:ZrgM8BoaLHh4knvJlTqsycOdHNt2oqiFCl/81fr9zP0=,tag:UfhMIr1ByFQhY9B9GpYAmQ==,type:str]
+    pgp:
+      - created_at: '2020-02-20T10:44:32Z'
+        enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            wcBMAyUpShfNkFB/AQgALJTUwdx6rAPckJ+reP5TEq+lXzHI1Zi7aHYOqZQBnA2s
+            z8h1gRce/fn7RPkmdsjsdSYmxGGKqwDXxUYsbN1aWXk6mb4Juktdvjl/GndF6PkU
+            TiN/l1GM6upgS+GPxA01NKsGkVmEtKR5NhsNEnE6OzY29+PFLsBX2vO1Zfg7kzBz
+            cDl6PT8fbFTEaFeyuYl9IslIV8yYsj1oHL3CF76RjCP6b18NSOHM23ytlH+KVaBV
+            ntoSVkTyWDx5o9iEHBEWSEGNpaCWWiEgkDEkA1VqMHdUlsW+IjZ8ggg5NJbcVtrG
+            YkN8rlGsNEzx+g4O4b1160A2K6AdTBcoGHwHD3u3XdLgAeTqT1ekE2N3yNT6w4sm
+            6uET4eTS4Cvg1OFCgOC34uUzlY3gbuVy20h8RNyQoAfhSN4DD2MexKqcMMCVCtn0
+            OhRMTP2jjOCe5Ex3/p3awcVxwx7qeJ26Vnfiwtg6ueFI5AA=
+            =tcnq
+            -----END PGP MESSAGE-----
+        fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.4.0

--- a/tests/integration/targets/vars_sops/test-extensions/host_vars/localhost.json
+++ b/tests/integration/targets/vars_sops/test-extensions/host_vars/localhost.json
@@ -1,0 +1,19 @@
+{
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"lastmodified": "2020-09-21T05:55:39Z",
+		"mac": "ENC[AES256_GCM,data:Igq1Of0up5cBLd4blecOJSeSqSc+qExqlcEmgaHbhL88e+YxfOd0HxIELYd4SuEAnzYxroQDop741frXLm3RbkFGJuoyW8Ur/GHHx/0e1GsNHGWJL3yfI5NKt0zb3D/pxLP0MrKmsdqlnEnewxeCb5M0xRDJqtRSLP4X4VHOop0=,iv:wzYu6PJsY1FtxuQnNhxDivCCUwfciZpBT232TS/qXZI=,tag:wg8Ijf3mqkfnt7BZ3DSBWQ==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2020-09-21T05:55:37Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nwcBMAyUpShfNkFB/AQgAY4Sok1zPyUO/sm8PcSWii6QDoOKkLB0LYNaCtJXcGttx\nenLAYAQtNKb4OgeSr2mrgUi5ceyMDAWME9xA0MQSHqU6IrTDRnBOM57wJb+4f029\nbh2PaPuwONcS6jZm+PobJ4sXbKrzigqF6NYdCHjc+3QSWuC2cklKWm1bX5Z0dBwu\nW+7pap7Ol+DCaWmrPx8qjZFR/E0aKcWQGuSryCfZNa6lXXlRxBB/47EBybG6Juks\nyGQBYDLyLxXsd4f0qVRs+A4ra5MkKF5UdAXjrBt5CgUjx2HVSqCD0ScQVwHuiC7L\n2hz3u2EDTB18kf87MFEs7M0Ef9+flJPozPw0Hjih4dLgAeSyNr8t/mZriYpTRIGg\nm1Ll4WKY4A7gkeHcfuA94oS488TgkuUeLeFnZyjEyWGNS8jcgcEXUQKtGKWm4DKk\nD73Cf7UUJOAu5Gdwq+SSwwXZLf1GkX3HSJzieu937OHvEwA=\n=ruyt\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.6.1"
+	}
+}

--- a/tests/integration/targets/vars_sops/test-extensions/host_vars/localhost.json.license
+++ b/tests/integration/targets/vars_sops/test-extensions/host_vars/localhost.json.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/integration/targets/vars_sops/test-extensions/hosts
+++ b/tests/integration/targets/vars_sops/test-extensions/hosts
@@ -1,0 +1,1 @@
+../test-success/hosts

--- a/tests/integration/targets/vars_sops/test-extensions/playbook.yml
+++ b/tests/integration/targets/vars_sops/test-extensions/playbook.yml
@@ -1,0 +1,14 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+- hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Make sure group_vars/all.yaml was found
+      debug:
+        msg: '{{ foo }}'
+    - name: Make sure group_vars/all/test.yaml was found
+      debug:
+        msg: '{{ bar }}'

--- a/tests/integration/targets/vars_sops/test-extensions/run.sh
+++ b/tests/integration/targets/vars_sops/test-extensions/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+set -e
+ANSIBLE_VARS_SOPS_PLUGIN_VALID_EXTENSIONS=".yml, .yaml, .json" \
+ansible-playbook playbook.yml -i hosts -v "$@"

--- a/tests/integration/targets/vars_sops/test-extensions/validate.sh
+++ b/tests/integration/targets/vars_sops/test-extensions/validate.sh
@@ -1,0 +1,1 @@
+../test-success/validate.sh


### PR DESCRIPTION
### Motivation
See #183.

### Changes description
Makes the valid extensions configurable by the `valid_extensions` option in the `[community.sops]` section of ansible.cfg, or by the `ANSIBLE_VARS_SOPS_PLUGIN_VALID_EXTENSIONS` environment variable.

### Additional notes
Fixes #183.
