### PR TITLE
Make sure 3.9.0 is tested in CI and mentioned in README; fix RPM URLs again

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -80,6 +80,7 @@ jobs:
           - 3.7.3
           - 3.8.0
           - 3.8.1
+          - 3.9.0
         python_version:
           - ''
         include:
@@ -124,7 +125,7 @@ jobs:
             sops_version: 3.8.1
           - ansible: stable-2.17
             docker_container: fedora39
-            sops_version: 3.8.1
+            sops_version: 3.9.0
           # devel
           - ansible: devel
             docker_container: quay.io/ansible-community/test-image:archlinux

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following table shows which versions of sops were tested with which versions
 |---|---|
 |0.1.0|`3.5.0+`|
 |1.0.6|`3.5.0+`|
-|`main` branch|`3.5.0`, `3.6.0`, `3.7.3`, `3.8.0`|
+|`main` branch|`3.5.0`, `3.6.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`|
 
 ## Tested with Ansible
 

--- a/changelogs/fragments/188-sops-3.9.0.yml
+++ b/changelogs/fragments/188-sops-3.9.0.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Fix RPM URL for the 3.9.0 release (https://github.com/ansible-collections/community.sops/pull/188)."

--- a/roles/install/vars/OS-RedHat.yml
+++ b/roles/install/vars/OS-RedHat.yml
@@ -24,7 +24,10 @@ _community_sops_install_system_packages_unsigned_github:
     }}{{
       _community_sops_install_effective_sops_version.replace('-', '.')
     }}{{
-      (_community_sops_install_effective_sops_version is version('3.8.0', '<')) | ternary('-1', '')
+      (
+        _community_sops_install_effective_sops_version is version('3.8.0', '<') or
+        _community_sops_install_effective_sops_version is version('3.9.0', '>=')
+      ) | ternary('-1', '')
     }}.{{
       ansible_facts.architecture
     }}.rpm


### PR DESCRIPTION
### Motivation
[sops 3.9.0](https://github.com/getsops/sops/releases/tag/v3.9.0) has just been released!

Unfortunately the RPM URLs changed once again... (Ref: https://github.com/getsops/sops/issues/1547)