### PR TITLE
vars plugin: remove superfluous leading underscores from option names

### DIFF
--- a/docs/docsite/rst/guide.rst
+++ b/docs/docsite/rst/guide.rst
@@ -418,7 +418,7 @@ See :ref:`VARIABLE_PLUGINS_ENABLED <VARIABLE_PLUGINS_ENABLED>` for more details 
 - ``.sops.yml``
 - ``.sops.json``
 
-(The list of extensions can be adjusted with :ansopt:`community.sops.sops#vars:_valid_extensions`.) The vars plugin will decrypt them and you can use their unencrypted content transparently.
+(The list of extensions can be adjusted with :ansopt:`community.sops.sops#vars:valid_extensions`.) The vars plugin will decrypt them and you can use their unencrypted content transparently.
 
 If you need to dynamically load encrypted variables, similar to the built-in :ansplugin:`ansible.builtin.include_vars action <ansible.builtin.include_vars#module>`, you can use the :ansplugin:`community.sops.load_vars action <community.sops.load_vars#module>` action. Please note that it is not a perfect replacement, since the built-in action relies on some hard-coded special casing in ansible-core which allows it to load the variables actually as variables (more precisely: as "unsafe" Jinja2 expressions which are automatically evaluated when used). Other action plugins, such as :ansplugin:`community.sops.load_vars#module`, cannot do that and have to load the variables as facts instead.
 

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -16,10 +16,10 @@ DOCUMENTATION = '''
         - Load encrypted YAML files into corresponding groups/hosts in C(group_vars/) and C(host_vars/) directories.
         - Files are encrypted prior to reading, making this plugin an effective companion to P(ansible.builtin.host_group_vars#vars) plugin.
         - Files are restricted to V(.sops.yaml), V(.sops.yml), V(.sops.json) extensions, unless configured otherwise
-          with O(_valid_extensions).
+          with O(valid_extensions).
         - Hidden files are ignored.
     options:
-      _valid_extensions:
+      valid_extensions:
         default: [".sops.yml", ".sops.yaml", ".sops.json"]
         description:
           - Check all of these extensions when looking for 'variable' files.
@@ -59,7 +59,7 @@ DOCUMENTATION = '''
             section: community.sops
         env:
           - name: ANSIBLE_VARS_SOPS_PLUGIN_CACHE
-      _disable_vars_plugin_temporarily:
+      disable_vars_plugin_temporarily:
         description:
           - Temporarily disable this plugin.
           - Useful if ansible-inventory is supposed to be run without decrypting secrets (in AWX for instance).
@@ -70,7 +70,7 @@ DOCUMENTATION = '''
           - name: SOPS_ANSIBLE_AWX_DISABLE_VARS_PLUGIN_TEMPORARILY
       handle_unencrypted_files:
         description:
-          - How to handle files that match the extensions in O(_valid_extensions) that are not SOPS encrypted.
+          - How to handle files that match the extensions in O(valid_extensions) that are not SOPS encrypted.
           - The default value V(error) will produce an error.
           - The value V(skip) will simply skip these files. This requires SOPS 3.9.0 or later.
           - The value V(warn) will skip these files and emit a warning. This requires SOPS 3.9.0 or later.
@@ -137,10 +137,10 @@ class VarsModule(BaseVarsPlugin):
         if cache is None:
             cache = self.get_option('cache')
 
-        if self.get_option('_disable_vars_plugin_temporarily'):
+        if self.get_option('disable_vars_plugin_temporarily'):
             return {}
 
-        valid_extensions = self.get_option('_valid_extensions')
+        valid_extensions = self.get_option('valid_extensions')
         handle_unencrypted_files = self.get_option('handle_unencrypted_files')
 
         data = {}


### PR DESCRIPTION
### Motivation
The names with the underscore are not used anywhere except in the code, so there's no reason to keep the underscores.

### Changes description
Remove the underscores.
