### PR TITLE
implement `sops decrypt --extract` for lookup plugin

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -407,3 +407,11 @@ releases:
       - 1.8.2.yml
       - deprecate-eol-ansible-core.yml
     release_date: '2024-08-13'
+  1.9.0:
+    changes:
+      minor_changes:
+        - sops lookup plugin - new option ``extract`` allows extracting a single
+          key out of a JSON or YAML file, equivalent to sops' ``decrypt --extract``.
+      fragments:
+        - 1.9.0.yml
+        - 200-lookup-extract.yaml

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -407,11 +407,3 @@ releases:
       - 1.8.2.yml
       - deprecate-eol-ansible-core.yml
     release_date: '2024-08-13'
-  1.9.0:
-    changes:
-      minor_changes:
-        - sops lookup plugin - new option ``extract`` allows extracting a single
-          key out of a JSON or YAML file, equivalent to sops' ``decrypt --extract``.
-      fragments:
-        - 1.9.0.yml
-        - 200-lookup-extract.yaml

--- a/changelogs/fragments/200-lookup-extract.yaml
+++ b/changelogs/fragments/200-lookup-extract.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+  - sops lookup plugin - new option ``extract`` allows extracting a single
+    key out of a JSON or YAML file, equivalent to sops' ``decrypt --extract``.

--- a/changelogs/fragments/200-lookup-extract.yaml
+++ b/changelogs/fragments/200-lookup-extract.yaml
@@ -1,3 +1,4 @@
 minor_changes:
   - sops lookup plugin - new option ``extract`` allows extracting a single
-    key out of a JSON or YAML file, equivalent to sops' ``decrypt --extract``.
+    key out of a JSON or YAML file, equivalent to sops' ``decrypt --extract``
+    (https://github.com/ansible-collections/community.sops/pull/200).

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -61,7 +61,7 @@ DOCUMENTATION = """
             default: false
         extract:
             description:
-                - Tell SOPS to extract a specific key from a json or yaml file.
+                - Tell SOPS to extract a specific key from a JSON or YAML file.
             type: str
     extends_documentation_fragment:
         - community.sops.sops

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -62,7 +62,7 @@ DOCUMENTATION = """
         extract:
             description:
                 - Tell SOPS to extract a specific key from a JSON or YAML file.
-                - Expects the same 'querystring' syntax as SOPS' C(--encrypt) option, 
+                - Expects the same 'querystring' syntax as SOPS' C(--encrypt) option,
                   for example V('["somekey"][0]').
                 - B(Note:) all quotes are mandatory and must be escaped appropriately.
             type: str

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -62,9 +62,9 @@ DOCUMENTATION = """
         extract:
             description:
                 - Tell SOPS to extract a specific key from a JSON or YAML file.
-                - Expects the same 'querystring' syntax as SOPS' C(--encrypt) option,
-                  for example V('["somekey"][0]').
-                - B(Note:) all quotes are mandatory and must be escaped appropriately.
+                - Expects a string with the same 'querystring' syntax as SOPS' C(--encrypt)
+                  option, for example V(["somekey"][0]).
+                - B(Note:) Escape quotes appropriately.
             type: str
             version_added: 1.9.0
     extends_documentation_fragment:

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -62,8 +62,9 @@ DOCUMENTATION = """
         extract:
             description:
                 - Tell SOPS to extract a specific key from a JSON or YAML file.
-                # - Expects the same 'query' syntax as SOPS' --encrypt option, 
-                #   e.g. '["somekey"][0]'. Note: all quotes are mandatory and must be escaped appropriately.
+                - Expects the same 'querystring' syntax as SOPS' C(--encrypt) option, 
+                  for example V('["somekey"][0]').
+                - B(Note:) all quotes are mandatory and must be escaped appropriately.
             type: str
             version_added: 1.9.0
     extends_documentation_fragment:

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -62,6 +62,8 @@ DOCUMENTATION = """
         extract:
             description:
                 - Tell SOPS to extract a specific key from a JSON or YAML file.
+                # - Expects the same 'query' syntax as SOPS' --encrypt option, 
+                #   e.g. '["somekey"][0]'. Note: all quotes are mandatory and must be escaped appropriately.
             type: str
             version_added: 1.9.0
     extends_documentation_fragment:

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -59,6 +59,10 @@ DOCUMENTATION = """
                   but return an empty string instead.
             type: bool
             default: false
+        extract:
+            description:
+                - Tell SOPS to extract a specific key from a json or yaml file.
+            type: str
     extends_documentation_fragment:
         - community.sops.sops
         - community.sops.sops.ansible_variables
@@ -126,6 +130,7 @@ class LookupModule(LookupBase):
         input_type = self.get_option('input_type')
         output_type = self.get_option('output_type')
         empty_on_not_exist = self.get_option('empty_on_not_exist')
+        extract = self.get_option('extract')
 
         ret = []
 
@@ -145,8 +150,8 @@ class LookupModule(LookupBase):
 
             try:
                 output = Sops.decrypt(
-                    lookupfile, display=display, rstrip=rstrip, decode_output=not use_base64,
-                    input_type=input_type, output_type=output_type, get_option_value=get_option_value)
+                    lookupfile, display=display, rstrip=rstrip, decode_output=(not use_base64),
+                    input_type=input_type, output_type=output_type, get_option_value=get_option_value, extract=extract)
             except SopsError as e:
                 raise AnsibleLookupError(to_native(e))
 

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -63,6 +63,7 @@ DOCUMENTATION = """
             description:
                 - Tell SOPS to extract a specific key from a JSON or YAML file.
             type: str
+            version_added: 1.9.0
     extends_documentation_fragment:
         - community.sops.sops
         - community.sops.sops.ansible_variables

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -91,7 +91,7 @@ def _create_env_variable(argument_name):
         env[argument_name] = value
 
     return f
-
+ 
 
 GENERAL_OPTIONS = {
     'age_key': _create_env_variable('SOPS_AGE_KEY'),
@@ -191,7 +191,7 @@ class SopsRunner(object):
         return process.returncode, output, err
 
     def decrypt(self, encrypted_file, content=None,
-                decode_output=True, rstrip=True, input_type=None, output_type=None, get_option_value=None):
+                decode_output=True, rstrip=True, input_type=None, output_type=None, get_option_value=None, extract=None):
         # Run sops directly, python module is deprecated
         command = [self.binary]
         command_post = []
@@ -206,6 +206,8 @@ class SopsRunner(object):
             command.extend(["--output-type", output_type])
         if self.version < (3, 9, 0):
             command.append("--decrypt")
+        if extract is not None:
+            command.extend(["--extract", extract])
         if content is not None:
             encrypted_file = '/dev/stdin'
         command.append(encrypted_file)
@@ -316,7 +318,7 @@ class Sops():
 
     @staticmethod
     def decrypt(encrypted_file, content=None,
-                display=None, decode_output=True, rstrip=True, input_type=None, output_type=None, get_option_value=None, module=None):
+                display=None, decode_output=True, rstrip=True, input_type=None, output_type=None, get_option_value=None, extract=None, module=None):
         runner = Sops.get_sops_runner_from_options(get_option_value, module=module, display=display)
         return runner.decrypt(
             encrypted_file,
@@ -326,6 +328,7 @@ class Sops():
             input_type=input_type,
             output_type=output_type,
             get_option_value=get_option_value,
+            extract=extract
         )
 
     @staticmethod

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -91,7 +91,7 @@ def _create_env_variable(argument_name):
         env[argument_name] = value
 
     return f
- 
+
 
 GENERAL_OPTIONS = {
     'age_key': _create_env_variable('SOPS_AGE_KEY'),

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -318,7 +318,7 @@ class Sops():
 
     @staticmethod
     def decrypt(encrypted_file, content=None,
-                display=None, decode_output=True, rstrip=True, input_type=None, output_type=None, get_option_value=None, extract=None, module=None):
+                display=None, decode_output=True, rstrip=True, input_type=None, output_type=None, get_option_value=None, module=None, extract=None):
         runner = Sops.get_sops_runner_from_options(get_option_value, module=module, display=display)
         return runner.decrypt(
             encrypted_file,

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -328,7 +328,7 @@ class Sops():
             input_type=input_type,
             output_type=output_type,
             get_option_value=get_option_value,
-            extract=extract
+            extract=extract,
         )
 
     @staticmethod

--- a/tests/integration/targets/lookup_sops/files/extract.json
+++ b/tests/integration/targets/lookup_sops/files/extract.json
@@ -1,0 +1,29 @@
+{
+	"foo": "ENC[AES256_GCM,data:yi6Y,iv:Eflygn9pqdyIXQisSPar0rOpdEScU7qo3ux8NDDyhpU=,tag:HwKdjMJaA/PW4N0nyFh/hA==,type:str]",
+	"bar": "ENC[AES256_GCM,data:nccS,iv:U41nqqAV2VpgW9R9rnxxRzN5SRkdvCNd58OQhhuaZYQ=,tag:dvlOpTuZvfvbcfD8HD7zvQ==,type:str]",
+	"baz": {
+		"bar": [
+			"ENC[AES256_GCM,data:CRMt,iv:6s5PcOsmqzNwGSyNGjxPDp1/cTXjp5QCXLC1717xAAw=,tag:NTyJsPgIQzBtTG2Sp4H4PQ==,type:str]",
+			"ENC[AES256_GCM,data:zIZJ,iv:KY4ABl0WieDmYEKUGfeAnDbA8/V79YpWg2bcrwUh0+E=,tag:4je4L70Fc0OmaOlCTjBedg==,type:str]",
+			"ENC[AES256_GCM,data:dbbZ,iv:BQVW4cEMnX+IFz3SXdenlDZv4o1iwpB+ZuFKV6qE0OI=,tag:kdb/8TNjoVvLiw3kna7okg==,type:str]"
+		]
+	},
+	"sops": {
+		"kms": null,
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2024-08-20T19:29:14Z",
+		"mac": "ENC[AES256_GCM,data:r8ECKCCtb6A3db1SXoaIFS/wTSOvab4Ui5GDHu0CXikCluGOqpWWHaVccdBIG5myvzSJPiLmxuFCaciiAjl4fQJCqrR4cau9Via2Kx7rbQzmXWsqXTCry/ISeqdKS4oQ5UL3+YcPq7mN3zkC8UIrDhc4CCbp9rFYqIKQp8xqnqo=,iv:wU7+lDSdQzfFfCudyfgCagVpmXBIRI1/gVSI/bUxpGk=,tag:kUPCPNkfhfc1ipzYC/sLaw==,type:str]",
+		"pgp": [
+			{
+				"created_at": "2024-08-20T19:27:56Z",
+				"enc": "-----BEGIN PGP MESSAGE-----\n\nhQEMAyUpShfNkFB/AQf/eMDcnG0qtwov/cfFAqUv9EE7RmNvipHB2hnnjO2fT1ud\nMZeiBbIZ3R5wWkZFsVHNO+pb3cv+txDDy2e8Td3FHQNZOqJ889D1reeXVVkHnMJ2\nwVJgy91m2f8eERmiRQO+jwa2UFPx80dI84ve8WT3jnxNyvxtrdm14WYNfv5ZOfte\n9IDnpv4YQZQj8BYh+Ag1//bRG7i8OcwBMAngMHbeYrW5WmHB6AH8PwJCqag7wA+5\nu7oRA0VppyIYrGUSogxcaOhhYBGcMVJxzvpIQvlGGC7SSXl4LcuRChRP/pCT5kQy\n44RQXnQTFwJR/l4RXixcQ3fqqgVMj/sOIyOgCFCegtJeAdEYCxDH59fomb5ejvuA\n96G0WlILPirSjvdECOQna/2XFcnKOPUPur0Rn/y9TUN6pIVaCeoJH+Fj6Y4P3Gk2\nJqWWYELsgKKmyf798Nv2yoTts2TYUEOZ374Y3F0HYQ==\n=RgW1\n-----END PGP MESSAGE-----",
+				"fp": "FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4"
+			}
+		],
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.9.0"
+	}
+}

--- a/tests/integration/targets/lookup_sops/files/extract.json.license
+++ b/tests/integration/targets/lookup_sops/files/extract.json.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/integration/targets/lookup_sops/files/extract.yaml
+++ b/tests/integration/targets/lookup_sops/files/extract.yaml
@@ -1,0 +1,33 @@
+foo: ENC[AES256_GCM,data:Ping,iv:+Ehv7ZgqHiqeZfx98xzZskOS31i53AXq79N7OOlCz3Y=,tag:+dhNWa+Se0xPLIbs2OI4OQ==,type:str]
+bar: ENC[AES256_GCM,data:CAdf,iv:JzgxIFcLl9KKP34GfMsZtemIrW8UJOATdML2jTJByak=,tag:X5LI0mDNep1+dfGifRm/DQ==,type:str]
+baz:
+    bar:
+        - ENC[AES256_GCM,data:sCC+,iv:n+Kz+sYPQckZfAiyWYsMde5q7kXCcJcrj6dTcmyTZIg=,tag:8EfSOibdo4W0kDA60iVJoQ==,type:str]
+        - ENC[AES256_GCM,data:ohn1,iv:nSIRsVG1OsOL9tqhswJAMPjqHI/TjX7kU8AnBPwFUMM=,tag:QR1Ja0IRis+mwgtqcMeoVg==,type:str]
+        - ENC[AES256_GCM,data:Bnl0,iv:SVGDhCFup2yeu01pvFMIJPmfmRYmWXdroWF9x5U8WQ4=,tag:lLVSoS8hHW6Yu8RPIcWa3w==,type:str]
+sops:
+    kms: []
+    gcp_kms: []
+    azure_kv: []
+    hc_vault: []
+    age: []
+    lastmodified: "2024-08-20T19:27:52Z"
+    mac: ENC[AES256_GCM,data:k1k3lpvr/KN0eaM3Fvf1lECjw1pUym56OY0WMwcGnEyM5SadE8t2LQ3nLd6CLoSqkZSlhmXZdtt2vMnE1gJzfvQ29joKd2GVwEKe0KVHzrwKEaHix48x0WAO7EYgk6g6jn+VFv0GeESZKOpn8niduOAFjr9Fz04UMyyQiC813M4=,iv:F3uwk6/nQSkHDMQSv3roXew3zkyAiL/I2CudS/Bs8ds=,tag:SyA6fZlBM0XLVTk8U5JIQQ==,type:str]
+    pgp:
+        - created_at: "2024-08-20T19:27:21Z"
+          enc: |-
+            -----BEGIN PGP MESSAGE-----
+
+            hQEMAyUpShfNkFB/AQf/YNyhkK7Dws/fuu4TnlzNm21HDbZu5Vbv/l8alB1QJelM
+            NbrtyOnG1SscUoWR567A7SMlXAHIGMJnyNz5rdL1Csl82wY9EHBV3QLy7zhrOvsz
+            GWzs5YFpT4YURzUDqOHuFTodmNQL1J/8/81ROHrH9aV2TdXmFRa4iBjqSvzK45As
+            xMuIV0AY4X54zRwPLXjnS8xlYQZfEY3dpRFeje2X92JsMYo8JZpgw1eVbzXc3+sU
+            pJfQZdiJJYUft7Zxz+5kjXSea3xBPOvoZOCDmFLjSv5nzo9dimmqek+S0rQGUfz7
+            LCcD43uz7KyZneGqrNwx7M2HW8dkH4izUXnDa/EqYNJRAS3X6AWklvBcAsoA20U1
+            i6UJr88mSJKExlZGjyPeTrSr2VBfbebnO+gxPMUK1+TI4qnr5cLwP1TvTOzuJjKw
+            CZUGPN6bA2CrGSgqZ8QsIxVB
+            =8HdX
+            -----END PGP MESSAGE-----
+          fp: FBC7B9E2A4F9289AC0C1D4843D16CEE4A27381B4
+    unencrypted_suffix: _unencrypted
+    version: 3.9.0

--- a/tests/integration/targets/lookup_sops/files/extract.yaml.license
+++ b/tests/integration/targets/lookup_sops/files/extract.yaml.license
@@ -1,0 +1,3 @@
+GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: Ansible Project

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -50,10 +50,14 @@
 
     - name: Test extract
       set_fact:
-        simple_yaml_with_extract: "{{ lookup('community.sops.sops', 'extract.yaml', extract=\"['foo']\") }}"
-        simple_json_with_extract: "{{ lookup('community.sops.sops', 'extract.json', extract=\"['bar']\") }}"
-        nested_yaml_with_extract: "{{ lookup('community.sops.sops', 'extract.yaml', extract=\"['baz']['bar'][0]\") }}"
-        nested_json_with_extract: "{{ lookup('community.sops.sops', 'extract.json', extract=\"['baz']['bar'][2]\") }}"
+        simple_yaml_with_extract: >-
+          {{ lookup('community.sops.sops', 'extract.yaml', extract="['foo']") }}
+        simple_json_with_extract: >-
+          {{ lookup('community.sops.sops', 'extract.json', extract="['bar']") }}
+        nested_yaml_with_extract: >-
+          {{ lookup('community.sops.sops', 'extract.yaml', extract="['baz']['bar'][0]") }}
+        nested_json_with_extract: >-
+          {{ lookup('community.sops.sops', 'extract.json', extract="['baz']['bar'][2]") }}
       register: sops_lookup_extract
 
     - assert:

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -48,6 +48,22 @@
           - "sops_lookup_simple is success"
           - "sops_success == 'foo: bar'"
 
+    - name: Test extract
+      set_fact:
+        simple_yaml_with_extract: "{{ lookup('community.sops.sops', 'extract.yaml', extract=\"['foo']\") }}"
+        simple_json_with_extract: "{{ lookup('community.sops.sops', 'extract.json', extract=\"['bar']\") }}"
+        nested_yaml_with_extract: "{{ lookup('community.sops.sops', 'extract.yaml', extract=\"['baz']['bar'][0]\") }}"
+        nested_json_with_extract: "{{ lookup('community.sops.sops', 'extract.json', extract=\"['baz']['bar'][2]\") }}"
+      register: sops_lookup_extract
+
+    - assert:
+        that:
+          - "sops_lookup_extract is success"
+          - "simple_yaml_with_extract == 'bar'"
+          - "simple_json_with_extract == 'baz'"
+          - "nested_yaml_with_extract == 'zab'"
+          - "nested_json_with_extract == 'oof'"
+          
     - name: Test rstrip
       set_fact:
         with_rstrip: "{{ lookup('community.sops.sops', 'rstrip.sops', rstrip=true) }}"


### PR DESCRIPTION
### Motivation
We have large encrypted yaml files and would like to lookup only specific keys.

### Changes description
Modified the Sops.decrypt function to accept an "extract" option.
