### PR TITLE
add ini as possible choice for input-type, output-type.

### DIFF
--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -42,6 +42,7 @@ options:
             - json
             - yaml
             - dotenv
+            - ini
         default: yaml
     output_type:
         description:
@@ -55,6 +56,7 @@ options:
             - json
             - yaml
             - dotenv
+            - ini
         default: yaml
     decode_output:
         description:
@@ -111,7 +113,7 @@ from ansible.utils.display import Display
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
 
 
-_VALID_TYPES = set(['binary', 'json', 'yaml', 'dotenv'])
+_VALID_TYPES = set(['binary', 'json', 'yaml', 'dotenv', 'ini'])
 
 
 def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sops', rstrip=True, decode_output=True,

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -41,6 +41,7 @@ DOCUMENTATION = """
                 - json
                 - yaml
                 - dotenv
+                - ini
         output_type:
             description:
                 - Tell SOPS how to interpret the decrypted file.
@@ -53,6 +54,7 @@ DOCUMENTATION = """
                 - json
                 - yaml
                 - dotenv
+                - ini
         empty_on_not_exist:
             description:
                 - When set to V(true), will not raise an error when a file cannot be found,


### PR DESCRIPTION
### Motivation
Sops has long been extended with the possibility to handle ini-files. But least until version 3.8.1, "ini" was not documented in `sops --help` as a possible value for `--input-secret` and `--output-secret`. The present state of this collection reflects that of this (by now also outdated) documentation. Since unsupported values are caught by ansible, this makes the collection unusable for ini files.

### Changes description
"ini" added as a possible value for `--input-secret` and `--output-secret`.