### PR TITLE
sops lookup, decrypt filter: add `ini` as valid input and output type

### DIFF
--- a/changelogs/fragments/204-input-output-type-ini.yml
+++ b/changelogs/fragments/204-input-output-type-ini.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - "decrypt filter plugin - now supports the input and output type ``ini`` (https://github.com/ansible-collections/community.sops/pull/204)."
+  - "sops lookup plugin - now supports the input and output type ``ini`` (https://github.com/ansible-collections/community.sops/pull/204)."

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -42,6 +42,7 @@ options:
             - json
             - yaml
             - dotenv
+            - ini
         default: yaml
     output_type:
         description:
@@ -55,6 +56,7 @@ options:
             - json
             - yaml
             - dotenv
+            - ini
         default: yaml
     decode_output:
         description:
@@ -111,7 +113,7 @@ from ansible.utils.display import Display
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
 
 
-_VALID_TYPES = set(['binary', 'json', 'yaml', 'dotenv'])
+_VALID_TYPES = set(['binary', 'json', 'yaml', 'dotenv', 'ini'])
 
 
 def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sops', rstrip=True, decode_output=True,

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -36,6 +36,7 @@ options:
             - There is no auto-detection since we do not have a filename. By default
               SOPS is told to treat the input as YAML. If that is wrong, please set this
               option to the correct value.
+            - The value V(ini) is available since community.sops 1.9.0.
         type: str
         choices:
             - binary
@@ -50,6 +51,7 @@ options:
             - Please note that the output is always text or bytes, depending on the value of O(decode_output).
               To parse the resulting JSON or YAML, use corresponding filters such as P(ansible.builtin.from_json#filter)
               and P(ansible.builtin.from_yaml#filter).
+            - The value V(ini) is available since community.sops 1.9.0.
         type: str
         choices:
             - binary

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -35,6 +35,7 @@ DOCUMENTATION = """
                 - By default, SOPS will chose the input type from the file extension.
                   If it detects the wrong type for a file, this could result in decryption
                   failing.
+                - The value V(ini) is available since community.sops 1.9.0.
             type: str
             choices:
                 - binary
@@ -48,6 +49,7 @@ DOCUMENTATION = """
                 - By default, SOPS will chose the output type from the file extension.
                   If it detects the wrong type for a file, this could result in decryption
                   failing.
+                - The value V(ini) is available since community.sops 1.9.0.
             type: str
             choices:
                 - binary

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -41,6 +41,7 @@ DOCUMENTATION = """
                 - json
                 - yaml
                 - dotenv
+                - ini
         output_type:
             description:
                 - Tell SOPS how to interpret the decrypted file.
@@ -53,6 +54,7 @@ DOCUMENTATION = """
                 - json
                 - yaml
                 - dotenv
+                - ini
         empty_on_not_exist:
             description:
                 - When set to V(true), will not raise an error when a file cannot be found,


### PR DESCRIPTION
This is basically #202 with the necessary documentation and changelog fragment. I cannot push directly to #202's branch, so here's a new PR for this...

Closes #202.