### PR TITLE
Run tests against SOPS 3.9.3

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -74,7 +74,7 @@ jobs:
           - 3.6.1
           - 3.7.3
           - 3.8.1
-          - 3.9.2
+          - 3.9.3
         python_version:
           - ''
         include:
@@ -112,10 +112,10 @@ jobs:
             sops_version: 3.7.0
           - ansible: devel
             docker_container: ubuntu2404
-            sops_version: 3.8.0
+            sops_version: 3.9.1
           - ansible: devel
             docker_container: fedora40
-            sops_version: 3.9.1
+            sops_version: 3.9.2
           - ansible: devel
             docker_container: quay.io/ansible-community/test-image:archlinux
             python_version: '3.13'

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The following table shows which versions of SOPS were tested with which versions
 
 |`community.sops` version|SOPS versions|
 |---|---|
-|`main` branch|`3.5.0`, `3.6.0`, `3.6.1`, `3.7.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`, `3.9.1`|, `3.9.2`
+|`main` branch|`3.5.0`, `3.6.0`, `3.6.1`, `3.7.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`, `3.9.1`, `3.9.2`, `3.9.3`|
 
 ## Code of Conduct
 


### PR DESCRIPTION
[SOPS 3.9.3](https://github.com/getsops/sops/releases/tag/v3.9.3) has just been released, so we should test against it as well.
