### PR TITLE
install role: work around ansible-core bug

### DIFF
--- a/changelogs/fragments/224-install.yml
+++ b/changelogs/fragments/224-install.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - "install role - ``sops_install_on_localhost=false`` was not working properly if the role was running on more than one host due to a bug in ansible-core
+     (https://github.com/ansible-collections/community.sops/issues/223, https://github.com/ansible-collections/community.sops/pull/224)."

--- a/roles/install/tasks/main.yml
+++ b/roles/install/tasks/main.yml
@@ -73,7 +73,7 @@
         allow_downgrade: '{{ true if _community_sops_install_allow_downgrade and sops_version != "latest" else omit }}'
       become: '{{ sops_become_on_install }}'
       delegate_to: '{{ "localhost" if sops_install_on_localhost else omit }}'
-      run_once: '{{ sops_install_on_localhost or omit }}'
+      run_once: '{{ sops_install_on_localhost }}'
       when: _community_sops_install_system_packages_actual | length > 0
 
     - name: Install unsigned system packages
@@ -83,7 +83,7 @@
         disable_gpg_check: true
       become: '{{ sops_become_on_install }}'
       delegate_to: '{{ "localhost" if sops_install_on_localhost else omit }}'
-      run_once: '{{ sops_install_on_localhost or omit }}'
+      run_once: '{{ sops_install_on_localhost }}'
       when: _community_sops_install_system_packages_unsigned_actual | length > 0
 
     - name: Install packages from URL/path (Debian)
@@ -92,7 +92,7 @@
         allow_downgrade: '{{ true if _community_sops_install_allow_downgrade and sops_version != "latest" else omit }}'
       become: '{{ sops_become_on_install }}'
       delegate_to: '{{ "localhost" if sops_install_on_localhost else omit }}'
-      run_once: '{{ sops_install_on_localhost or omit }}'
+      run_once: '{{ sops_install_on_localhost }}'
       when: _community_sops_install_system_package_deb_actual is string
 
     - name: Set results


### PR DESCRIPTION
Fixes #223.

`run_once: "{{ omit }}"` simply does not work (and probably never did)...
