### PR TITLE
[WIP] Allow to load vars with expressions evaluated lazily

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -31,6 +31,7 @@ jobs:
           - stable-2.17
           - stable-2.18
           - devel
+          - refs/pull/84621/head
     runs-on: ubuntu-latest
     steps:
       - name: Perform sanity testing
@@ -49,6 +50,7 @@ jobs:
       matrix:
         ansible:
           - devel
+          - refs/pull/84621/head
         docker_container:
           - ubuntu2204
           - ubuntu2404
@@ -152,6 +154,7 @@ jobs:
       matrix:
         ansible:
           - devel
+          - refs/pull/84621/head
         docker_container:
           - ''
         python_version:

--- a/changelogs/fragments/225-data-tagging.yml
+++ b/changelogs/fragments/225-data-tagging.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "load_vars - make evaluation compatible with Data Tagging in upcoming ansible-core release (https://github.com/ansible-collections/community.sops/pull/225)."

--- a/plugins/modules/load_vars.py
+++ b/plugins/modules/load_vars.py
@@ -34,14 +34,14 @@ options:
       - If set to V(ignore), expressions will not be evaluated, but treated as regular strings.
       - If set to V(evaluate-on-load), expressions will be evaluated on execution of this module, in other words, when the
         file is loaded.
-      - Unfortunately, there is no way for non-core modules to handle expressions "unsafe", in other words, evaluate them
-        only on use. This can only achieved by M(ansible.builtin.include_vars), which unfortunately cannot handle SOPS-encrypted
-        files.
+      - If set to V(lazy-evaluation), expressions will be lazily evaluated. This requires ansible-core 2.19 or newer
+        and is the same behavior than M(ansible.builtin.include_vars). V(lazy-evaluation) has been added in community.sops 2.1.0.
     type: str
     default: ignore
     choices:
       - ignore
       - evaluate-on-load
+      - lazy-evaluation
 extends_documentation_fragment:
   - community.sops.sops
   - community.sops.attributes

--- a/tests/integration/targets/load_vars/tasks/main.yml
+++ b/tests/integration/targets/load_vars/tasks/main.yml
@@ -23,7 +23,7 @@
 
     - assert:
         that:
-          - '"value of expressions must be one of: ignore, evaluate-on-load, got: invalid value" in load_vars_invalid_value.msg'
+          - '"value of expressions must be one of: ignore, evaluate-on-load, lazy-evaluation, got: invalid value" in load_vars_invalid_value.msg'
 
     - name: Test load_vars with missing file
       community.sops.load_vars:
@@ -124,3 +124,35 @@
         that:
           - load_vars_expr_evaluated_now_2 is success
           - test2_2 == 'something_else'
+
+    - when: ansible_version.full is version('2.19', '>=')
+      block:
+        - set_fact:
+            to_be_defined_earlier: something_defined_before
+            bar_2: baz
+
+        - name: Test load_vars with expressions evaluated lazily
+          community.sops.load_vars:
+            file: proper-vars-2.sops.yaml
+            expressions: lazy-evaluation
+          register: load_vars_expr_lazy_evaluated
+
+        - assert:
+            that:
+              - load_vars_expr_lazy_evaluated is success
+              - test1_2 == 'baz'
+              - test2_2 == 'something_defined_before'
+              - test3_2[0] == 'baz'
+              - test4_2.test_4_2_1 == 'bazbaz'
+
+        - set_fact:
+            to_be_defined_earlier: something_else
+            bar_2: buzz
+
+        - assert:
+            that:
+              - load_vars_expr_lazy_evaluated is success
+              - test1_2 == 'buzz'
+              - test2_2 == 'something_else'
+              - test3_2[0] == 'buzz'
+              - test4_2.test_4_2_1 == 'buzzbuzz'


### PR DESCRIPTION
With Data Tagging, this is finally possible for community.sops.load_vars.

Unfortunately, the DT PR also deprecates top-level facts, so every time you use anything loaded by community.sops.load_vars, you get a big fat deprecation warning :sob:

I hope it's possible to either add an API so that action plugins can finally set variables, or move the deprecation to a later ansible-core version until such an API exists.

(This PR currently contains #225.)