### PR TITLE
Add SOPS 3.10.0 to CI and README

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -59,6 +59,7 @@ jobs:
           - 3.7.3
           - 3.8.1
           - 3.9.3
+          - 3.10.0
         python_version:
           - ''
         gha_container:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following table shows which versions of SOPS were tested with which versions
 
 |`community.sops` version|SOPS versions|
 |---|---|
-|`main` branch|`3.5.0`, `3.6.0`, `3.6.1`, `3.7.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`, `3.9.1`, `3.9.2`, `3.9.3`|
+|`main` branch|`3.5.0`, `3.6.0`, `3.6.1`, `3.7.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`, `3.9.1`, `3.9.2`, `3.9.3`, `3.10.0`|
 
 ## Code of Conduct
 


### PR DESCRIPTION
SOPS 3.10.0 has been released: https://github.com/getsops/sops/releases/tag/v3.10.0