### PR TITLE
Cover more SOPS versions in CI

### DIFF
--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -59,7 +59,7 @@ jobs:
           - 3.7.3
           - 3.8.1
           - 3.9.3
-          - 3.10.0
+          - 3.10.2
         python_version:
           - ''
         gha_container:
@@ -68,7 +68,7 @@ jobs:
           # 2.15
           - ansible: stable-2.15
             docker_container: ubuntu2004
-            sops_version: 3.5.0
+            sops_version: 3.10.0
           - ansible: stable-2.15
             docker_container: ubuntu2204
             sops_version: 3.6.0
@@ -85,7 +85,7 @@ jobs:
             sops_version: 3.8.0
           - ansible: stable-2.17
             docker_container: fedora39
-            sops_version: 3.8.1
+            sops_version: 3.10.1
           # 2.18
           - ansible: stable-2.18
             docker_container: ubuntu2404

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following table shows which versions of SOPS were tested with which versions
 
 |`community.sops` version|SOPS versions|
 |---|---|
-|`main` branch|`3.5.0`, `3.6.0`, `3.6.1`, `3.7.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`, `3.9.1`, `3.9.2`, `3.9.3`, `3.10.0`|
+|`main` branch|`3.5.0`, `3.6.0`, `3.6.1`, `3.7.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`, `3.9.1`, `3.9.2`, `3.9.3`, `3.10.0`, `3.10.1`, `3.10.2`|
 
 ## Code of Conduct
 


### PR DESCRIPTION
3.10.2 is out.