### PR TITLE
CI: Bump Alpine 3.21 to 3.22 and Fedora 41 to 42

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -123,7 +123,7 @@ debian_bullseye = "quay.io/ansible-community/test-image:debian-bullseye"
 debian_bookworm = "quay.io/ansible-community/test-image:debian-bookworm"
 
 for core_version in ["devel"]:
-    for docker_container in ["ubuntu2204", "ubuntu2404", "fedora41"]:
+    for docker_container in ["ubuntu2204", "ubuntu2404", "fedora42"]:
         for sops_version in ["3.5.0", "3.6.1", "3.7.3", "3.8.1", "3.9.3", "3.10.2"]:
             add_target(core_version=core_version, docker_container=docker_container, sops_version=sops_version)
 add_target(core_version="2.15", docker_container="ubuntu2004", sops_version="3.10.0")
@@ -157,14 +157,14 @@ add_target(core_version="devel", docker_container="ubuntu2204", target="gha/inst
 add_target(core_version="devel", docker_container=archlinux, python_version="3.13", target="gha/install/3/", github_latest_detection="auto")
 add_target(core_version="devel", docker_container=debian_bookworm, python_version="3.11", target="gha/install/3/", github_latest_detection="auto")
 add_target(core_version="2.16", docker_container=debian_bullseye, python_version="3.9", target="gha/install/3/", github_latest_detection="auto")
-add_target(core_version="devel", docker_container="fedora41", target="gha/install/3/", github_latest_detection="auto")
+add_target(core_version="devel", docker_container="fedora42", target="gha/install/3/", github_latest_detection="auto")
 add_target(core_version="devel", docker_container="ubuntu2204", target="gha/install/3/", github_latest_detection="api")
 add_target(core_version="devel", docker_container="ubuntu2404", target="gha/install/3/", github_latest_detection="latest-release")
-add_target(core_version="devel", docker_container="alpine321", target="gha/install/3/", github_latest_detection="auto")
+add_target(core_version="devel", docker_container="alpine322", target="gha/install/3/", github_latest_detection="auto")
 # ARM 64
-add_target(core_version="devel", docker_container="fedora41", target="gha/install/1/", github_latest_detection="auto", gha_container="ubuntu-24.04-arm")
+add_target(core_version="devel", docker_container="fedora42", target="gha/install/1/", github_latest_detection="auto", gha_container="ubuntu-24.04-arm")
 add_target(core_version="devel", docker_container="ubuntu2204", target="gha/install/2/", github_latest_detection="auto", gha_container="ubuntu-24.04-arm")
-add_target(core_version="devel", docker_container="alpine321", target="gha/install/3/", github_latest_detection="auto", gha_container="ubuntu-24.04-arm")
+add_target(core_version="devel", docker_container="alpine322", target="gha/install/3/", github_latest_detection="auto", gha_container="ubuntu-24.04-arm")
 
 
 @nox.session(name="ansible-test-integration", default=False, python=False, requires=session_names)


### PR DESCRIPTION
##### SUMMARY
ansible-core devel updated its CI containers.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
