### PR TITLE
CI: Ansible-core devel EE: use Python 3.12

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -68,8 +68,8 @@ test_playbooks = ["tests/ee/all.yml"]
 config.images.base_image.name = "docker.io/redhat/ubi9:latest"
 config.dependencies.ansible_core.package_pip = "https://github.com/ansible/ansible/archive/devel.tar.gz"
 config.dependencies.ansible_runner.package_pip = "ansible-runner"
-config.dependencies.python_interpreter.package_system = "python3.11 python3.11-pip python3.11-wheel python3.11-cryptography"
-config.dependencies.python_interpreter.python_path = "/usr/bin/python3.11"
+config.dependencies.python_interpreter.package_system = "python3.12 python3.12-pip python3.12-wheel python3.12-cryptography"
+config.dependencies.python_interpreter.python_path = "/usr/bin/python3.12"
 config.additional_build_steps.append_final = [
     "RUN ansible-playbook -v community.sops.install_localhost",
 ]


### PR DESCRIPTION
##### SUMMARY
The EE test with ansible-core devel is failing since the EE has Python 3.11, which ansible-core devel no longer supports.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
