### PR TITLE
[stable-1] CI: Replace ansible-core devel with 2.19 in EE tests

### DIFF
--- a/.github/workflows/ee.yml
+++ b/.github/workflows/ee.yml
@@ -45,8 +45,8 @@ jobs:
         exclude:
           - ansible_core: ''
         include:
-          - name: ansible-core devel @ RHEL UBI 9
-            ansible_core: https://github.com/ansible/ansible/archive/devel.tar.gz
+          - name: ansible-core 2.19 @ RHEL UBI 9
+            ansible_core: https://github.com/ansible/ansible/archive/stable-2.19.tar.gz
             ansible_runner: ansible-runner
             other_deps: |2
                 python_interpreter:


### PR DESCRIPTION
ansible-core devel requires Python 3.12+, and our EE test has only Python 3.11. Also the stable-1 branch generally stopped testing against ansible-core devel, and tests against ansible-core 2.19 max.