### PR TITLE
ansible-core 2.20: avoid deprecated functionality

### DIFF
--- a/changelogs/fragments/260-deprecations.yml
+++ b/changelogs/fragments/260-deprecations.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - "Avoid deprecated functionality in ansible-core 2.20 (https://github.com/ansible-collections/community.sops/pull/260)."

--- a/plugins/plugin_utils/action_module.py
+++ b/plugins/plugin_utils/action_module.py
@@ -23,7 +23,7 @@ import traceback
 from ansible.errors import AnsibleError
 from ansible.module_utils import six
 from ansible.module_utils.basic import SEQUENCETYPE, remove_values
-from ansible.module_utils.common._collections_compat import (
+from collections.abc import (
     Mapping
 )
 from ansible.module_utils.common.validation import (


### PR DESCRIPTION
##### SUMMARY
ansible.module_utils._text and ansible.module_utils.common._collections_compat have been deprecated.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
various
