### PR TITLE
Add SOPS 3.11.0 to test matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The following table shows which versions of SOPS were tested with which versions
 
 |`community.sops` version|SOPS versions|
 |---|---|
-|`main` branch|`3.5.0`, `3.6.0`, `3.6.1`, `3.7.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`, `3.9.1`, `3.9.2`, `3.9.3`, `3.10.0`, `3.10.1`, `3.10.2`|
+|`main` branch|`3.5.0`, `3.6.0`, `3.6.1`, `3.7.0`, `3.7.3`, `3.8.0`, `3.8.1`, `3.9.0`, `3.9.1`, `3.9.2`, `3.9.3`, `3.10.0`, `3.10.1`, `3.10.2`, `3.11.0`|
 
 ## Code of Conduct
 

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -108,7 +108,7 @@ ansible_vars = { override_sops_version = "3.9.3" }
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"
 docker = ["ubuntu2204", "ubuntu2404", "fedora42"]
-ansible_vars = { override_sops_version = "3.10.2" }
+ansible_vars = { override_sops_version = "3.11.0" }
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "2.15"


### PR DESCRIPTION
SOPS 3.11.0 has been released: https://github.com/getsops/sops/releases/tag/v3.11.0
