### PR TITLE
Add basic type checking

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,14 @@
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[mypy]
+# check_untyped_defs = True
+# disallow_untyped_defs = True -- not yet feasible
+
+# strict = True -- only try to enable once everything is typed
+strict_equality = True
+
+[mypy-ansible.*]
+# ansible-core has partial typing information
+follow_untyped_imports = True

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -31,7 +31,12 @@ yamllint_config = ".yamllint"
 yamllint_config_plugins = ".yamllint-docs"
 yamllint_config_plugins_examples = ".yamllint-examples"
 yamllint_config_extra_docs = ".yamllint-extra-docs"
-run_mypy = false
+run_mypy = true
+mypy_config = ".mypy.ini"
+mypy_extra_deps = [
+    "types-mock",
+    "types-PyYAML",
+]
 
 [sessions.docs_check]
 validate_collection_refs="all"

--- a/plugins/action/load_vars.py
+++ b/plugins/action/load_vars.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import typing as t
 from collections.abc import Sequence, Mapping
 
 from ansible.module_utils.common.text.converters import to_native
@@ -20,15 +21,18 @@ except ImportError:
     HAS_DATATAGGING = False
 
 try:
-    from ansible.plugins.action import VariableLayer
+    from ansible.plugins.action import VariableLayer  # type: ignore[attr-defined]
     HAS_REGISTER_HOST_VARIABLES = True
 except ImportError:
     HAS_REGISTER_HOST_VARIABLES = False
 
+if t.TYPE_CHECKING:
+    from ansible_collections.community.sops.plugins.plugin_utils.action_module import AnsibleActionModule
+
 display = Display()
 
 
-def _make_safe(value):
+def _make_safe(value: t.Any) -> t.Any:
     if HAS_DATATAGGING and isinstance(value, str):
         return _trust_as_template(value)
     return value
@@ -36,7 +40,7 @@ def _make_safe(value):
 
 class ActionModule(ActionModuleBase):
 
-    def _load(self, filename, module):
+    def _load(self, filename: str, module: AnsibleActionModule) -> dict:
         def get_option_value(argument_name):
             return module.params.get(argument_name)
 

--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -294,7 +294,7 @@ class SopsRunner(object):
             raise SopsError(path, 0, 'Cannot decode filestatus result: %s' % exc, operation='inspect')
 
 
-_SOPS_RUNNER_CACHE = dict()
+_SOPS_RUNNER_CACHE = dict()  # type: dict[str, SopsRunner]
 
 
 class Sops():

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -110,7 +110,7 @@ try:
 except ImportError:
     YAML_IMP_ERR = traceback.format_exc()
     HAS_YAML = False
-    yaml = None
+    yaml = None  # type: ignore[assignment]  # use better type later...
 
 
 def get_data_type(module):

--- a/plugins/plugin_utils/action_module.py
+++ b/plugins/plugin_utils/action_module.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import abc
 import copy
 import traceback
+import typing as t
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.basic import SEQUENCETYPE, remove_values
@@ -24,6 +25,12 @@ from ansible.plugins.action import ActionBase
 
 from ansible.module_utils.common.arg_spec import ArgumentSpecValidator
 from ansible.module_utils.errors import UnsupportedError
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+safe_eval: Callable[[t.Any, t.Any, t.Any], t.Any] | None
 
 try:
     from ansible.module_utils.common.validation import (

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -101,6 +101,7 @@ seealso:
 """
 
 import os
+import typing as t
 from collections.abc import Sequence, Mapping
 
 from ansible.errors import AnsibleParserError
@@ -121,11 +122,11 @@ except ImportError:
 
 display = Display()
 
-FOUND = {}
-DECRYPTED = {}
+FOUND: dict[str, list[str]] = {}
+DECRYPTED: dict[str, bytes] = {}
 
 
-def _make_safe(value):
+def _make_safe(value: t.Any) -> t.Any:
     if isinstance(value, str):
         # must come *before* Sequence, as strings are also instances of Sequence
         if HAS_DATATAGGING and isinstance(value, str):


### PR DESCRIPTION
The controller-only parts of the collection are Python 3.7+, so we can do some type checking there.

I was about to use type hints in new controller-only code when I noticed that there is no checking yet. This PR prepares that work.