### PR TITLE
Check types and better handle sops_binary for plugins

### DIFF
--- a/plugins/doc_fragments/sops.py
+++ b/plugins/doc_fragments/sops.py
@@ -125,6 +125,12 @@ options:
     version_added: 1.0.0
 """
 
+    ANSIBLE_PLUGIN = r'''
+options:
+  sops_binary:
+    type: str
+'''
+
     ANSIBLE_VARIABLES = r'''
 options:
   sops_binary:

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -108,6 +108,7 @@ from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.utils.display import Display
 
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
+from ansible_collections.community.sops.plugins.plugin_utils._args import wrap_get_option_value_check_types
 
 
 _VALID_TYPES = set(['binary', 'json', 'yaml', 'dotenv', 'ini'])
@@ -165,10 +166,19 @@ def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sop
     data = to_bytes(data)
     try:
         output = Sops.decrypt(
-            None, content=data, display=Display(), rstrip=rstrip, decode_output=decode_output,
-            input_type=input_type, output_type=output_type, get_option_value=get_option_value)
+            None,
+            content=data,
+            display=Display(),
+            rstrip=rstrip,
+            decode_output=decode_output,
+            input_type=input_type,
+            output_type=output_type,
+            get_option_value=wrap_get_option_value_check_types(get_option_value, add_encrypt_specific=False),
+        )
     except SopsError as e:
         raise AnsibleFilterError(to_native(e))
+    except ValueError as e:
+        raise AnsibleFilterError(f"Error in community.sops.decrypt filter: {e}")
 
     return output
 

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -117,8 +117,10 @@ _raw:
 import base64
 
 from ansible.errors import AnsibleLookupError
-from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.compat.version import LooseVersion
+from ansible.plugins.lookup import LookupBase
+from ansible.release import __version__ as ansible_version
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
 from ansible_collections.community.sops.plugins.plugin_utils._args import wrap_get_option_value_plugin_path
 
@@ -139,7 +141,20 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        sops_binary, sops_binary_origin = self.get_option_and_origin("sops_binary")
+        try:
+            sops_binary, sops_binary_origin = self.get_option_and_origin("sops_binary")
+            if sops_binary is None and (
+                LooseVersion(ansible_version) < LooseVersion("2.18.8")
+                or
+                LooseVersion(ansible_version) == LooseVersion("2.19.0")
+            ):
+                # Ansible-core < 2.18.8 and 2.19.0 are broken: https://github.com/ansible/ansible/issues/85480
+                sops_binary = self.get_option("sops_binary")
+                sops_binary_origin = "Direct"
+        except AttributeError:
+            # Ansible-core 2.15 has no get_option_and_origin()!
+            sops_binary = self.get_option("sops_binary")
+            sops_binary_origin = "Direct"
         get_option_value = wrap_get_option_value_plugin_path(
             self.get_option,
             sops_binary=sops_binary,

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -68,6 +68,7 @@ options:
     version_added: 1.9.0
 extends_documentation_fragment:
   - community.sops.sops
+  - community.sops.sops.ansible_plugin
   - community.sops.sops.ansible_variables
   - community.sops.sops.ansible_env
   - community.sops.sops.ansible_ini
@@ -119,6 +120,7 @@ from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils.common.text.converters import to_native
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
+from ansible_collections.community.sops.plugins.plugin_utils._args import wrap_get_option_value_plugin_path
 
 from ansible.utils.display import Display
 display = Display()
@@ -137,8 +139,12 @@ class LookupModule(LookupBase):
 
         ret = []
 
-        def get_option_value(argument_name):
-            return self.get_option(argument_name)
+        sops_binary, sops_binary_origin = self.get_option_and_origin("sops_binary")
+        get_option_value = wrap_get_option_value_plugin_path(
+            self.get_option,
+            sops_binary=sops_binary,
+            sops_binary_origin=sops_binary_origin,
+        )
 
         for term in terms:
             display.debug("Sops lookup term: %s" % term)

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -67,8 +67,8 @@ options:
     type: str
     version_added: 1.9.0
 extends_documentation_fragment:
+  - community.sops.sops.ansible_plugin  # must come before community.sops.sops!
   - community.sops.sops
-  - community.sops.sops.ansible_plugin
   - community.sops.sops.ansible_variables
   - community.sops.sops.ansible_env
   - community.sops.sops.ansible_ini

--- a/plugins/plugin_utils/_args.py
+++ b/plugins/plugin_utils/_args.py
@@ -23,17 +23,14 @@ from ansible.utils.path import unfrackpath as _unfrackpath
 from ansible_collections.community.sops.plugins.module_utils.sops import get_sops_argument_spec as _get_sops_argument_spec
 
 if t.TYPE_CHECKING:
-    from collections.abc import Callable, Mapping
+    from collections.abc import Callable, Mapping  # pragma: no cover
 
 
 def wrap_get_option_value(
     get_option_value: Callable[[str], t.Any],
     *,
-    overrides: Mapping[str, t.Any] | None = None,
+    overrides: Mapping[str, t.Any],
 ) -> Callable[[str], t.Any]:
-    if overrides is None:
-        overrides = {}
-
     def new_get_option_value(option: str) -> t.Any:
         if option in overrides:
             return overrides[option]
@@ -55,10 +52,11 @@ def wrap_get_option_value_plugin_path(
             candidate = candidate.replace("{{CWD}}", os.getcwd())
         basedir = sops_binary_origin if sops_binary_origin and os.path.isabs(sops_binary_origin) and os.path.exists(_to_bytes(sops_binary_origin)) else None
         candidate = _unfrackpath(candidate, follow=False, basedir=basedir)
-        # ...
+        # Check whether the candidate is a file:
         if os.path.isfile(candidate):
             sops_binary = candidate
         else:
+            # If not, fall back to what a module would do with the path
             sops_binary = os.path.expanduser(os.path.expandvars(sops_binary))
     overrides = {"sops_binary": sops_binary}
     return wrap_get_option_value(get_option_value, overrides=overrides)
@@ -77,7 +75,7 @@ def _ensure_type_impl(value: t.Any, *, option_type: str) -> t.Any:
         return _check_type_float(value)
     if option_type == "path":
         return _check_type_path(_check_type_str(value, allow_conversion=False))
-    raise RuntimeError(f"Unknown option type {option_type!r}")
+    raise AssertionError(f"Unknown option type {option_type!r}")  # pragma: no cover
 
 
 def _ensure_type(value: t.Any, *, option_type: str, elements_type: str | None, sensitive: bool) -> t.Any:
@@ -86,9 +84,9 @@ def _ensure_type(value: t.Any, *, option_type: str, elements_type: str | None, s
     if option_type != "list":
         return _ensure_type_impl(value, option_type=option_type)
     value = _check_type_list(value)
-    if elements_type is not None:
-        return [_ensure_type_impl(v, option_type=elements_type) for v in value]
-    return value
+    if elements_type is None:
+        return value
+    return [_ensure_type_impl(v, option_type=elements_type) for v in value]
 
 
 def wrap_get_option_value_check_types(

--- a/plugins/plugin_utils/_args.py
+++ b/plugins/plugin_utils/_args.py
@@ -62,20 +62,18 @@ def wrap_get_option_value_plugin_path(
     return wrap_get_option_value(get_option_value, overrides=overrides)
 
 
+_TYPE_CHECKS = {
+    "dict": _check_type_dict,
+    "bool": _check_type_bool,
+    "int": _check_type_int,
+    "float": _check_type_float,
+    "str": lambda value: _check_type_str(value, allow_conversion=False),
+    "path": lambda value: _check_type_path(_check_type_str(value, allow_conversion=False)),
+}
+
+
 def _ensure_type_impl(value: t.Any, *, option_type: str) -> t.Any:
-    if option_type == "str":
-        return _check_type_str(value, allow_conversion=False)
-    if option_type == "dict":
-        return _check_type_dict(value)
-    if option_type == "bool":
-        return _check_type_bool(value)
-    if option_type == "int":
-        return _check_type_int(value)
-    if option_type == "float":
-        return _check_type_float(value)
-    if option_type == "path":
-        return _check_type_path(_check_type_str(value, allow_conversion=False))
-    raise AssertionError(f"Unknown option type {option_type!r}")  # pragma: no cover
+    return _TYPE_CHECKS[option_type](value)
 
 
 def _ensure_type(value: t.Any, *, option_type: str, elements_type: str | None, sensitive: bool) -> t.Any:
@@ -85,7 +83,9 @@ def _ensure_type(value: t.Any, *, option_type: str, elements_type: str | None, s
         return _ensure_type_impl(value, option_type=option_type)
     value = _check_type_list(value)
     if elements_type is None:
-        return value
+        # Our options do not have a list without 'elements', so this is unreachable.
+        # We still want to keep this code though...
+        return value  # pragma: no cover
     return [_ensure_type_impl(v, option_type=elements_type) for v in value]
 
 

--- a/plugins/plugin_utils/_args.py
+++ b/plugins/plugin_utils/_args.py
@@ -1,0 +1,112 @@
+# Copyright (c) 2026 Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# Note that this module util is **PRIVATE** to the collection. It can have breaking changes at any time.
+# Do not use this from other collections or standalone plugins/modules!
+
+from __future__ import annotations
+
+import os
+import typing as t
+
+from ansible.module_utils.common.text.converters import to_bytes as _to_bytes
+from ansible.module_utils.common.validation import check_type_bool as _check_type_bool
+from ansible.module_utils.common.validation import check_type_dict as _check_type_dict
+from ansible.module_utils.common.validation import check_type_int as _check_type_int
+from ansible.module_utils.common.validation import check_type_float as _check_type_float
+from ansible.module_utils.common.validation import check_type_list as _check_type_list
+from ansible.module_utils.common.validation import check_type_path as _check_type_path
+from ansible.module_utils.common.validation import check_type_str as _check_type_str
+from ansible.utils.path import unfrackpath as _unfrackpath
+
+from ansible_collections.community.sops.plugins.module_utils.sops import get_sops_argument_spec as _get_sops_argument_spec
+
+if t.TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+
+def wrap_get_option_value(
+    get_option_value: Callable[[str], t.Any],
+    *,
+    overrides: Mapping[str, t.Any] | None = None,
+) -> Callable[[str], t.Any]:
+    if overrides is None:
+        overrides = {}
+
+    def new_get_option_value(option: str) -> t.Any:
+        if option in overrides:
+            return overrides[option]
+        return get_option_value(option)
+
+    return new_get_option_value
+
+
+def wrap_get_option_value_plugin_path(
+    get_option_value: Callable[[str], t.Any],
+    *,
+    sops_binary: t.Any,
+    sops_binary_origin: str | None = "Direct",
+) -> Callable[[str], t.Any]:
+    if isinstance(sops_binary, str):
+        candidate = sops_binary
+        # ansible.config.manager.resolve_path() handles {{CWD}}:
+        if "{{CWD}}" in candidate:
+            candidate = candidate.replace("{{CWD}}", os.getcwd())
+        basedir = sops_binary_origin if sops_binary_origin and os.path.isabs(sops_binary_origin) and os.path.exists(_to_bytes(sops_binary_origin)) else None
+        candidate = _unfrackpath(candidate, follow=False, basedir=basedir)
+        # ...
+        if os.path.isfile(candidate):
+            sops_binary = candidate
+        else:
+            sops_binary = os.path.expanduser(os.path.expandvars(sops_binary))
+    overrides = {"sops_binary": sops_binary}
+    return wrap_get_option_value(get_option_value, overrides=overrides)
+
+
+def _ensure_type_impl(value: t.Any, *, option_type: str) -> t.Any:
+    if option_type == "str":
+        return _check_type_str(value, allow_conversion=False)
+    if option_type == "dict":
+        return _check_type_dict(value)
+    if option_type == "bool":
+        return _check_type_bool(value)
+    if option_type == "int":
+        return _check_type_int(value)
+    if option_type == "float":
+        return _check_type_float(value)
+    if option_type == "path":
+        return _check_type_path(_check_type_str(value, allow_conversion=False))
+    raise RuntimeError(f"Unknown option type {option_type!r}")
+
+
+def _ensure_type(value: t.Any, *, option_type: str, elements_type: str | None, sensitive: bool) -> t.Any:
+    if value is None:
+        return None
+    if option_type != "list":
+        return _ensure_type_impl(value, option_type=option_type)
+    value = _check_type_list(value)
+    if elements_type is not None:
+        return [_ensure_type_impl(v, option_type=elements_type) for v in value]
+    return value
+
+
+def wrap_get_option_value_check_types(
+    get_option_value: Callable[[str], t.Any],
+    *,
+    add_encrypt_specific: bool,
+) -> Callable[[str], t.Any]:
+    overrides: dict[str, t.Any] = {}
+    for option, data in _get_sops_argument_spec(add_encrypt_specific=add_encrypt_specific).items():
+        value = get_option_value(option)
+        try:
+            value = _ensure_type(
+                value,
+                option_type=data.get("type", "str"),
+                elements_type=data.get("elements"),
+                sensitive=data.get("no_log", False),
+            )
+        except TypeError as exc:
+            raise ValueError(f"option {option} has invalid value: {exc}")
+        overrides[option] = value
+    return wrap_get_option_value(get_option_value, overrides=overrides)

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -88,6 +88,7 @@ options:
 extends_documentation_fragment:
   - ansible.builtin.vars_plugin_staging
   - community.sops.sops
+  - community.sops.sops.ansible_plugin
   - community.sops.sops.ansible_env
   - community.sops.sops.ansible_ini
 seealso:
@@ -112,6 +113,7 @@ from ansible.plugins.vars import BaseVarsPlugin
 from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
+from ansible_collections.community.sops.plugins.plugin_utils._args import wrap_get_option_value_plugin_path
 
 try:
     from ansible.template import trust_as_template as _trust_as_template
@@ -149,8 +151,12 @@ class VarsModule(BaseVarsPlugin):
 
         super().get_vars(loader, path, entities)
 
-        def get_option_value(argument_name):
-            return self.get_option(argument_name)
+        sops_binary, sops_binary_origin = self.get_option_and_origin("sops_binary")
+        get_option_value = wrap_get_option_value_plugin_path(
+            self.get_option,
+            sops_binary=sops_binary,
+            sops_binary_origin=sops_binary_origin,
+        )
 
         if cache is None:
             cache = self.get_option('cache')

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -151,7 +151,12 @@ class VarsModule(BaseVarsPlugin):
 
         super().get_vars(loader, path, entities)
 
-        sops_binary, sops_binary_origin = self.get_option_and_origin("sops_binary")
+        try:
+            sops_binary, sops_binary_origin = self.get_option_and_origin("sops_binary")
+        except AttributeError:
+            # Ansible-core 2.15 has no get_option_and_origin()!
+            sops_binary = self.get_option("sops_binary")
+            sops_binary_origin = "Direct"
         get_option_value = wrap_get_option_value_plugin_path(
             self.get_option,
             sops_binary=sops_binary,

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -87,8 +87,8 @@ options:
       - name: ANSIBLE_VARS_SOPS_PLUGIN_HANDLE_UNENCRYPTED_FILES
 extends_documentation_fragment:
   - ansible.builtin.vars_plugin_staging
+  - community.sops.sops.ansible_plugin  # must come before community.sops.sops!
   - community.sops.sops
-  - community.sops.sops.ansible_plugin
   - community.sops.sops.ansible_env
   - community.sops.sops.ansible_ini
 seealso:

--- a/tests/integration/targets/filter_decrypt/tasks/main.yml
+++ b/tests/integration/targets/filter_decrypt/tasks/main.yml
@@ -5,26 +5,39 @@
 
 - when: sops_installed
   block:
-    - name: Test bad parameter detection (1/2)
+    - name: Test bad parameter detection (1/3)
       set_fact:
         sops_bad_input_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(input_type='foo') }}"
       ignore_errors: true
       register: sops_bad_input_type
 
-    - name: Test bad parameter detection (2/2)
+    - name: Test bad parameter detection (2/3)
       set_fact:
         sops_bad_output_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(output_type=23) }}"
       ignore_errors: true
       register: sops_bad_output_type
 
+    - name: Test bad parameter detection (3/3)
+      set_fact:
+        sops_bad_output_type: "{{ 'this-is-not: a sops file' | community.sops.decrypt(sops_binary=42) }}"
+      ignore_errors: true
+      register: sops_bad_binary
+
     - assert:
         that:
           - "sops_bad_input_type is failed"
-          - "'input_type must be one of' in sops_bad_input_type.msg"
-          - "'; got \"foo\"' in sops_bad_input_type.msg"
+          - >-
+            'input_type must be one of' in sops_bad_input_type.msg
+          - >-
+            '; got "foo"' in sops_bad_input_type.msg
           - "sops_bad_output_type is failed"
-          - "'output_type must be one of' in sops_bad_output_type.msg"
-          - "'; got \"23\"' in sops_bad_output_type.msg"
+          - >-
+            'output_type must be one of' in sops_bad_output_type.msg
+          - >-
+            '; got "23"' in sops_bad_output_type.msg
+          - "sops_bad_binary is failed"
+          - >-
+            "Error in community.sops.decrypt filter: option sops_binary has invalid value: '42' is not a string and conversion is not allowed" in sops_bad_binary.msg
 
     - name: Test decrypt of non-sops file
       set_fact:

--- a/tests/integration/targets/lookup_sops/tasks/main.yml
+++ b/tests/integration/targets/lookup_sops/tasks/main.yml
@@ -41,12 +41,14 @@
     - name: Test simple lookup
       set_fact:
         sops_success: "{{ lookup('community.sops.sops', 'simple.sops.yaml') }}"
+        sops_success_2: "{{ lookup('community.sops.sops', 'simple.sops.yaml', sops_binary='sops') }}"
       register: sops_lookup_simple
 
     - assert:
         that:
           - "sops_lookup_simple is success"
           - "sops_success == 'foo: bar'"
+          - "sops_success_2 == 'foo: bar'"
 
     - name: Test extract
       set_fact:


### PR DESCRIPTION
See #288 for the problem with `sops_binary` in plugins. Also the `decrypt` filter does no type checking *at all*.

Fixes #288.
