### PR TITLE
Add ansible-lint to CI

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -1,0 +1,26 @@
+---
+# Copyright (c) Ansible Project
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+skip_list:
+  # Ignore rules that make no sense:
+  - galaxy[tags]
+  - galaxy[version-incorrect]
+  - meta-runtime[unsupported-version]
+  - no-changed-when
+  - sanity[cannot-ignore]  # some of the rules you cannot ignore actually MUST be ignored, like yamllint:unparsable-with-libyaml
+  - yaml  # we're using yamllint ourselves
+  - var-naming[no-role-prefix]
+
+  # To be checked and maybe fixed:
+  # (currently none)
+  - fqcn
+  - jinja[spacing]
+  - no-handler
+  - name
+  - risky-file-permissions
+  - role-name
+  - schema[tasks]
+  - schema[vars]
+  - var-naming

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -24,3 +24,9 @@ skip_list:
   - schema[tasks]
   - schema[vars]
   - var-naming
+
+exclude_paths:
+  # Ansible-lint uses "ansible-playbook --syntax-check" as its "syntax check",
+  # which bails out on roles it cannot find. The following playbooks are 100% valid,
+  # but we need to skip them due to ansible-lint's syntax check's deficiencies...
+  - tests/integration/targets/vars_sops/setup.yml

--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -76,6 +76,8 @@ skip_directories = [
 [sessions.build_import_check]
 run_galaxy_importer = true
 
+[sessions.ansible_lint]
+
 [sessions.ansible_test_sanity]
 include_devel = true
 


### PR DESCRIPTION
##### SUMMARY
Add ansible-lint to CI.

Doesn't yet work because `syntax-check` really, really sucks.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
