### PR TITLE
feat(encrypt): Allow edit-based mode to minimize diffs

### DIFF
--- a/plugins/module_utils/sops.py
+++ b/plugins/module_utils/sops.py
@@ -10,6 +10,8 @@ import collections
 import json
 import os
 import re
+import shlex
+import tempfile
 
 from ansible.module_utils.common.text.converters import to_text, to_native
 
@@ -270,6 +272,47 @@ class SopsRunner(object):
 
         return output
 
+    def edit(self, path, data, cwd=None, get_option_value=None):
+        """Use 'sops edit' to update an existing encrypted file in place.
+
+        Only re-encrypts changed values, producing cleaner git diffs.
+        Returns True if the file was modified, False if content was unchanged.
+        """
+        tmp_fd, tmp_name = tempfile.mkstemp(prefix='.ansible_sops_edit_')
+        try:
+            os.write(tmp_fd, data)
+            os.close(tmp_fd)
+
+            command = [self.binary]
+            command_post = []
+            env = os.environ.copy()
+            self._add_options(command, command_post, env, get_option_value, GENERAL_OPTIONS)
+            if self.version >= (3, 9, 0):
+                command.append("edit")
+            command.extend(command_post)
+            command.append(path)
+
+            env['EDITOR'] = "cp {0}".format(shlex.quote(tmp_name))
+
+            exit_code, output, err = self._run_command(command, env=env, cwd=cwd)
+
+            if err:
+                self._debug(u'Unexpected stderr:\n' + to_text(err, errors='surrogate_or_strict'))
+
+            if exit_code == 200:
+                # FileHasNotBeenModified - content was unchanged
+                return False
+
+            if exit_code != 0:
+                raise SopsError(path, exit_code, err, decryption=False)
+
+            return True
+        finally:
+            try:
+                os.remove(tmp_name)
+            except Exception:
+                pass
+
     def has_filestatus(self):
         return self.version >= (3, 9, 0)
 
@@ -347,6 +390,14 @@ class Sops():
             output_type=output_type,
             get_option_value=get_option_value,
             filename=filename,
+        )
+
+    @staticmethod
+    def edit(path, data, display=None, cwd=None, get_option_value=None, module=None):
+        runner = Sops.get_sops_runner_from_options(get_option_value, module=module, display=display)
+        return runner.edit(
+            path, data, cwd=cwd,
+            get_option_value=get_option_value,
         )
 
 

--- a/plugins/modules/sops_encrypt.py
+++ b/plugins/modules/sops_encrypt.py
@@ -220,12 +220,23 @@ def main():
                 output_type = 'json'
             elif path.endswith(('.yml', '.yaml')):
                 output_type = 'yaml'
-            data = Sops.encrypt(
-                data=input_data, cwd=directory, input_type=input_type, output_type=output_type,
-                filename=os.path.relpath(path, directory) if directory is not None else path,
-                get_option_value=get_option_value, module=module,
-            )
-            write_file(module, data)
+            if os.path.exists(path) and not module.params['force']:
+                # Use 'sops edit' to only re-encrypt changed values (cleaner git diffs).
+                # Skip when force=true: we haven't verified the file is valid sops,
+                # and force semantically means "fully re-encrypt".
+                actually_changed = Sops.edit(
+                    path=path, data=input_data, cwd=directory,
+                    get_option_value=get_option_value, module=module,
+                )
+                if not actually_changed:
+                    changed = False
+            else:
+                data = Sops.encrypt(
+                    data=input_data, cwd=directory, input_type=input_type, output_type=output_type,
+                    filename=os.path.relpath(path, directory) if directory is not None else path,
+                    get_option_value=get_option_value, module=module,
+                )
+                write_file(module, data)
     except SopsError as e:
         module.fail_json(msg=to_text(e))
 

--- a/tests/integration/targets/sops_encrypt/tasks/main.yml
+++ b/tests/integration/targets/sops_encrypt/tasks/main.yml
@@ -423,3 +423,61 @@
           - value_1.data == text_value_1
           - '"data" in value_2'
           - value_2.data.startswith('ENC[')
+
+    # Minimal diff via sops edit (unchanged keys preserve encrypted values)
+
+    - name: Define test values for sops edit minimal diff
+      set_fact:
+        edit_json_1:
+          key_a: value_a
+          key_b: value_b
+          key_c: value_c
+        edit_json_2:
+          key_a: value_a
+          key_b: changed_b
+          key_c: value_c
+
+    - name: Create JSON file for edit minimal diff test
+      community.sops.sops_encrypt:
+        path: "{{ remote_tmp_dir }}/test_edit_diff.json"
+        content_json: "{{ edit_json_1 }}"
+      register: result_edit_create
+
+    - slurp:
+        src: "{{ remote_tmp_dir }}/test_edit_diff.json"
+      register: slurp_edit_before
+    - set_fact:
+        enc_before: "{{ slurp_edit_before.content | b64decode | from_json }}"
+
+    - name: Update one key via sops edit path (minimal diff)
+      community.sops.sops_encrypt:
+        path: "{{ remote_tmp_dir }}/test_edit_diff.json"
+        content_json: "{{ edit_json_2 }}"
+      register: result_edit_update
+
+    - slurp:
+        src: "{{ remote_tmp_dir }}/test_edit_diff.json"
+      register: slurp_edit_after
+    - set_fact:
+        enc_after: "{{ slurp_edit_after.content | b64decode | from_json }}"
+        dec_after: "{{ slurp_edit_after.content | b64decode | community.sops.decrypt(output_type='json') | from_json }}"
+
+    - name: Verify sops edit idempotency (no change)
+      community.sops.sops_encrypt:
+        path: "{{ remote_tmp_dir }}/test_edit_diff.json"
+        content_json: "{{ edit_json_2 }}"
+      register: result_edit_idempotent
+
+    - name: Verify sops edit results
+      assert:
+        that:
+          - result_edit_create is changed
+          - result_edit_update is changed
+          - result_edit_idempotent is not changed
+          # Decrypted content should be correct
+          - dec_after == edit_json_2
+          # Unchanged keys should have identical encrypted values (minimal diff)
+          - enc_before.key_a == enc_after.key_a
+          - enc_before.key_c == enc_after.key_c
+          # Changed key should have a different encrypted value
+          - enc_before.key_b != enc_after.key_b


### PR DESCRIPTION
### Motivation

- Before: when you change even one line, the whole file is re-encrypted
- After: if you change one line, only one line will be changed in the encypted result

### Changes description

If the file defined in `path` exists, it executes `sops` in the "edit" mode, passing the existing file and the content to be encrypted. As a result, `sops` changes only modified lines.

I agree, this is a controversial way to do that, and it is better to submit a patch to the SOPS repo instead. I just needed something now.

### Additional notes

Idea from: https://github.com/getsops/sops/issues/1587
