### PR TITLE
CI: Use ansible-core devel EE on UBI 10 with Python 3.14

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -396,14 +396,14 @@ gha_container = "ubuntu-24.04-arm"
 ansible_vars = { github_latest_detection = "auto" }
 
 [[sessions.ee_check.execution_environments]]
-name = "devel-ubi-9"
-description = "ansible-core devel @ RHEL UBI 9"
+name = "devel-ubi-10"
+description = "ansible-core devel @ RHEL UBI 10"
 test_playbooks = ["tests/ee/all.yml"]
-config.images.base_image.name = "docker.io/redhat/ubi9:latest"
+config.images.base_image.name = "docker.io/redhat/ubi10:latest"
 config.dependencies.ansible_core.package_pip = "https://github.com/ansible/ansible/archive/devel.tar.gz"
 config.dependencies.ansible_runner.package_pip = "ansible-runner"
-config.dependencies.python_interpreter.package_system = "python3.12 python3.12-pip python3.12-wheel python3.12-cryptography"
-config.dependencies.python_interpreter.python_path = "/usr/bin/python3.12"
+config.dependencies.python_interpreter.package_system = "python3.14 python3.14-pip python3.14-cryptography"
+config.dependencies.python_interpreter.python_path = "/usr/bin/python3.14"
 config.additional_build_steps.append_final = [
     "RUN ansible-playbook -v community.sops.install_localhost",
 ]


### PR DESCRIPTION
##### SUMMARY
UBI 9 with Python 3.12 no longer can install ansible-core devel.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
