### PR TITLE
CI: Replace Alpine 3.23 with 3.24 for devel

### DIFF
--- a/antsibull-nox.toml
+++ b/antsibull-nox.toml
@@ -401,12 +401,12 @@ ansible_vars = { github_latest_detection = "auto" }
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"
-docker = "alpine323"
+docker = "alpine324"
 ansible_vars = { github_latest_detection = "auto" }
 
 [[sessions.ansible_test_integration.groups.sessions]]
 ansible_core = "devel"
-docker = "alpine323"
+docker = "alpine324"
 gha_container = "ubuntu-24.04-arm"
 ansible_vars = { github_latest_detection = "auto" }
 


### PR DESCRIPTION
##### SUMMARY
ansible-core devel bumped its Alpine 3.23 VM/container image to 3.24.

##### ISSUE TYPE
- Test Pull Request

##### COMPONENT NAME
CI
