### PR TITLE
WIP: Use new Secrets API

### DIFF
--- a/plugins/action/load_vars.py
+++ b/plugins/action/load_vars.py
@@ -11,6 +11,7 @@ from ansible.module_utils.common.text.converters import to_native
 from ansible.utils.display import Display
 
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, get_sops_argument_spec
+from ansible_collections.community.sops.plugins.module_utils._secrets import mark_values_as_secrets
 
 from ansible_collections.community.sops.plugins.plugin_utils.action_module import ActionModuleBase, ArgumentSpec
 
@@ -82,6 +83,7 @@ class ActionModule(ActionModuleBase):
                 name=dict(type='str'),
                 expressions=dict(type='str', default='ignore', choices=['ignore', 'evaluate-on-load', 'lazy-evaluation']),
                 return_method=dict(type='str', default='auto', choices=['auto', 'facts-only', 'vars-only']),
+                register_values_as_secrets=dict(type='bool', default=True),
             ),
         )
         argument_spec.argument_spec.update(get_sops_argument_spec())
@@ -91,6 +93,8 @@ class ActionModule(ActionModuleBase):
         expressions = module.params['expressions']
         if expressions == 'lazy-evaluation' and not HAS_DATATAGGING:
             module.fail_json(msg='expressions=lazy-evaluation requires ansible-core 2.19+ with Data Tagging support.')
+
+        register_values_as_secrets = module.params['register_values_as_secrets']
 
         return_method_str = module.params['return_method']
         if return_method_str == 'auto':
@@ -125,6 +129,9 @@ class ActionModule(ActionModuleBase):
             'ansible_included_var_files': files,
             '_ansible_no_log': True,
         }
+
+        if register_values_as_secrets:
+            value = mark_values_as_secrets(value)
 
         if return_as_facts:
             result['ansible_facts'] = value

--- a/plugins/doc_fragments/sops.py
+++ b/plugins/doc_fragments/sops.py
@@ -129,6 +129,14 @@ options:
 options:
   sops_binary:
     type: str
+  age_key:
+    secret: true
+  aws_secret_access_key:
+    secret: true
+  aws_session_token:
+    secret: true
+  gcp_oauth_access_token:
+    secret: true
 '''
 
     ANSIBLE_VARIABLES = r'''

--- a/plugins/filter/decrypt.py
+++ b/plugins/filter/decrypt.py
@@ -61,6 +61,15 @@ options:
         V(false) to prevent mangling the data with UTF-8 decoding.
     type: bool
     default: true
+  register_result_as_secret:
+    description:
+      - Whether the decrypted result should be marked as a secret,
+        and thus will get redacted whenever its values appears in log or console output.
+      - This requires ansible-core 2.22+. See R(Masking secrets in Ansible output, secret_masking) for more information.
+      - B(Note) this is mainly recommended for binary files.
+    type: bool
+    default: true
+    version_added: 2.5.0
 extends_documentation_fragment:
   - community.sops.sops
 seealso:
@@ -108,6 +117,7 @@ from ansible.module_utils.common.text.converters import to_bytes, to_native
 from ansible.utils.display import Display
 
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
+from ansible_collections.community.sops.plugins.module_utils._secrets import mark_as_secret
 from ansible_collections.community.sops.plugins.plugin_utils._args import wrap_get_option_value_check_types
 
 
@@ -117,7 +127,8 @@ _VALID_TYPES = set(['binary', 'json', 'yaml', 'dotenv', 'ini'])
 def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sops', rstrip=True, decode_output=True,
                    aws_profile=None, aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None,
                    config_path=None, enable_local_keyservice=True, keyservice=None, age_key=None, age_keyfile=None, age_ssh_private_keyfile=None,
-                   age_key_cmd=None, age_ssh_private_key_cmd=None, gcp_oauth_access_token=None, gcp_kms_client_type=None):
+                   age_key_cmd=None, age_ssh_private_key_cmd=None, gcp_oauth_access_token=None, gcp_kms_client_type=None,
+                   register_result_as_secret=True):
     '''Decrypt sops-encrypted data.'''
 
     # Check parameters
@@ -179,6 +190,9 @@ def decrypt_filter(data, input_type='yaml', output_type='yaml', sops_binary='sop
         raise AnsibleFilterError(to_native(e))
     except ValueError as e:
         raise AnsibleFilterError(f"Error in community.sops.decrypt filter: {e}")
+
+    if register_result_as_secret:
+        mark_as_secret(to_native(output))
 
     return output
 

--- a/plugins/lookup/sops.py
+++ b/plugins/lookup/sops.py
@@ -66,6 +66,15 @@ options:
       - B(Note:) Escape quotes appropriately.
     type: str
     version_added: 1.9.0
+  register_result_as_secret:
+    description:
+      - Whether the decrypted result should be marked as a secret,
+        and thus will get redacted whenever its values appears in log or console output.
+      - This requires ansible-core 2.22+. See R(Masking secrets in Ansible output, secret_masking) for more information.
+      - B(Note) this is mainly recommended for binary files.
+    type: bool
+    default: true
+    version_added: 2.5.0
 extends_documentation_fragment:
   - community.sops.sops.ansible_plugin  # must come before community.sops.sops!
   - community.sops.sops
@@ -122,6 +131,7 @@ from ansible.module_utils.compat.version import LooseVersion
 from ansible.plugins.lookup import LookupBase
 from ansible.release import __version__ as ansible_version
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
+from ansible_collections.community.sops.plugins.module_utils._secrets import mark_as_secret
 from ansible_collections.community.sops.plugins.plugin_utils._args import wrap_get_option_value_plugin_path
 
 from ansible.utils.display import Display
@@ -138,6 +148,7 @@ class LookupModule(LookupBase):
         output_type = self.get_option('output_type')
         empty_on_not_exist = self.get_option('empty_on_not_exist')
         extract = self.get_option('extract')
+        register_result_as_secret = self.get_option('register_result_as_secret')
 
         ret = []
 
@@ -181,6 +192,9 @@ class LookupModule(LookupBase):
 
             if use_base64:
                 output = to_native(base64.b64encode(output))
+
+            if register_result_as_secret:
+                output = mark_as_secret(output)
 
             ret.append(output)
 

--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 Felix Fontein <felix@fontein.de>
+# GNU General Public License v3.0+ (see LICENSES/GPL-3.0-or-later.txt or https://www.gnu.org/licenses/gpl-3.0.txt)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+try:
+    from collections.abc import Sequence, Mapping
+    string_type = str
+except ImportError:
+    # Python 2 compat
+    # pylint: disable-next=ansible-bad-import-from
+    from collections import Sequence, Mapping  # type: ignore[attr-defined]
+    # pylint: disable-next=undefined-variable
+    string_type = unicode  # type: ignore[misc,name-defined]
+
+
+try:
+    from ansible.module_utils.secrets import register_secret  # type: ignore[import-not-found]
+    HAS_SECRETS_API = True
+except ImportError:
+    HAS_SECRETS_API = False
+
+
+def _mark_recursively(value):
+    if isinstance(value, Mapping):
+        return {k: _mark_recursively(v) for k, v in value.items()}
+    if isinstance(value, string_type):
+        return register_secret(value)
+    if isinstance(value, Sequence):
+        return [_mark_recursively(v) for v in value]
+    return value
+
+
+def mark_values_as_secrets(value):
+    """Register all strings appearing in the (potentially nested) data structure value secrets."""
+    if HAS_SECRETS_API:
+        value = _mark_recursively(value)
+    return value
+
+
+def mark_as_secret(value):  # type: (string_type) -> string_type
+    """Register a string as a secret."""
+    if HAS_SECRETS_API:
+        value = register_secret(value)
+    return value

--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -18,26 +18,33 @@ except ImportError:
 
 
 try:
-    from ansible.module_utils.secrets import register_secret  # type: ignore[import-not-found]
+    from ansible.module_utils.secrets import register_secret, register_secrets  # type: ignore[import-not-found]
+
     HAS_SECRETS_API = True
 except ImportError:
     HAS_SECRETS_API = False
 
 
-def _mark_recursively(value):
+def _collect_recursively(value, collected_values, int_to_string):
     if isinstance(value, Mapping):
-        return {k: _mark_recursively(v) for k, v in value.items()}
-    if isinstance(value, string_type):
-        return register_secret(value)
-    if isinstance(value, Sequence):
-        return [_mark_recursively(v) for v in value]
-    return value
+        for v in value.items():
+            _collect_recursively(v, collected_values, int_to_string=int_to_string)
+    elif isinstance(value, string_type):
+        collected_values.append(value)
+    elif isinstance(value, Sequence):
+        for v in value:
+            _collect_recursively(v, collected_values, int_to_string=int_to_string)
+    elif int_to_string and isinstance(value, int):
+        collected_values.append(string_type(value))
 
 
-def mark_values_as_secrets(value):
-    """Register all strings appearing in the (potentially nested) data structure value secrets."""
+def mark_values_as_secrets(value, int_to_string=False):
+    """Register all strings appearing in the (potentially nested) data structure ``value`` as secrets."""
     if HAS_SECRETS_API:
-        value = _mark_recursively(value)
+        collected_values = []
+        _collect_recursively(value, collected_values, int_to_string=int_to_string)
+        if collected_values:
+            register_secrets(collected_values)
     return value
 
 

--- a/plugins/module_utils/_secrets.py
+++ b/plugins/module_utils/_secrets.py
@@ -11,7 +11,7 @@ try:
     string_type = str
 except ImportError:
     # Python 2 compat
-    # pylint: disable-next=ansible-bad-import-from
+    # pylint: disable-next=ansible-bad-import-from,deprecated-class
     from collections import Sequence, Mapping  # type: ignore[attr-defined]
     # pylint: disable-next=undefined-variable
     string_type = unicode  # type: ignore[misc,name-defined]

--- a/plugins/modules/load_vars.py
+++ b/plugins/modules/load_vars.py
@@ -59,6 +59,16 @@ options:
         - Return the results always as variables.
         - Fails for ansible-core < 2.21.
     version_added: 2.3.0
+  register_values_as_secrets:
+    description:
+      - Whether the loaded values should marked as secrets,
+        and thus will get redacted whenever such values appear in log or console output.
+      - This requires ansible-core 2.22+. See R(Masking secrets in Ansible output, secret_masking) for more information.
+      - B(Note) that the plugin right now cannot distinguish between values that were encrypted and values that were not encrypted.
+        All values will be marked as secrets. This might change in the future.
+    type: bool
+    default: true
+    version_added: 2.5.0
 extends_documentation_fragment:
   - community.sops.sops
   - community.sops.attributes

--- a/plugins/vars/sops.py
+++ b/plugins/vars/sops.py
@@ -85,6 +85,21 @@ options:
         section: community.sops
     env:
       - name: ANSIBLE_VARS_SOPS_PLUGIN_HANDLE_UNENCRYPTED_FILES
+  register_values_as_secrets:
+    description:
+      - Whether the loaded values should marked as secrets,
+        and thus will get redacted whenever such values appear in log or console output.
+      - This requires ansible-core 2.22+. See R(Masking secrets in Ansible output, secret_masking) for more information.
+      - B(Note) that the plugin right now cannot distinguish between values that were encrypted and values that were not encrypted.
+        All values will be marked as secrets. This might change in the future.
+    type: bool
+    default: true
+    version_added: 2.5.0
+    ini:
+      - key: register_values_as_secrets
+        section: community.sops
+    env:
+      - name: ANSIBLE_VARS_SOPS_PLUGIN_REGISTER_VALUES_AS_SECRETS
 extends_documentation_fragment:
   - ansible.builtin.vars_plugin_staging
   - community.sops.sops.ansible_plugin  # must come before community.sops.sops!
@@ -113,6 +128,7 @@ from ansible.plugins.vars import BaseVarsPlugin
 from ansible.utils.display import Display
 from ansible.utils.vars import combine_vars
 from ansible_collections.community.sops.plugins.module_utils.sops import Sops, SopsError
+from ansible_collections.community.sops.plugins.module_utils._secrets import mark_values_as_secrets
 from ansible_collections.community.sops.plugins.plugin_utils._args import wrap_get_option_value_plugin_path
 
 try:
@@ -171,6 +187,7 @@ class VarsModule(BaseVarsPlugin):
 
         valid_extensions = self.get_option('valid_extensions')
         handle_unencrypted_files = self.get_option('handle_unencrypted_files')
+        register_values_as_secrets = self.get_option('register_values_as_secrets')
 
         data = {}
         for entity in entities:
@@ -254,5 +271,8 @@ class VarsModule(BaseVarsPlugin):
                     raise AnsibleParserError(to_native(e))
                 except Exception as e:
                     raise AnsibleParserError('Unexpected error in the SOPS vars plugin: %s' % to_native(e))
+
+        if register_values_as_secrets:
+            data = mark_values_as_secrets(data)
 
         return data

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,7 +1,7 @@
-plugins/lookup/sops.py validate-modules:invalid-documentation  # choices as dict
+plugins/lookup/sops.py validate-modules:invalid-documentation  # choices as dict, secret not supported
 plugins/modules/load_vars.py validate-modules:invalid-documentation  # choices as dict
 plugins/modules/sops_encrypt.py validate-modules:invalid-documentation  # choices as dict
-plugins/vars/sops.py validate-modules:invalid-documentation  # choices as dict
+plugins/vars/sops.py validate-modules:invalid-documentation  # choices as dict, secret not supported
 tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error

--- a/tests/sanity/ignore-2.16.txt
+++ b/tests/sanity/ignore-2.16.txt
@@ -1,7 +1,7 @@
-plugins/lookup/sops.py validate-modules:invalid-documentation  # choices as dict
+plugins/lookup/sops.py validate-modules:invalid-documentation  # choices as dict, secret not supported
 plugins/modules/load_vars.py validate-modules:invalid-documentation  # choices as dict
 plugins/modules/sops_encrypt.py validate-modules:invalid-documentation  # choices as dict
-plugins/vars/sops.py validate-modules:invalid-documentation  # choices as dict
+plugins/vars/sops.py validate-modules:invalid-documentation  # choices as dict, secret not supported
 tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error

--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,3 +1,5 @@
+plugins/lookup/sops.py validate-modules:invalid-documentation  # secret not supported
+plugins/vars/sops.py validate-modules:invalid-documentation  # secret not supported
 tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error

--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,3 +1,5 @@
+plugins/lookup/sops.py validate-modules:invalid-documentation  # secret not supported
+plugins/vars/sops.py validate-modules:invalid-documentation  # secret not supported
 tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error

--- a/tests/sanity/ignore-2.19.txt
+++ b/tests/sanity/ignore-2.19.txt
@@ -1,3 +1,5 @@
+plugins/lookup/sops.py validate-modules:invalid-documentation  # secret not supported
+plugins/vars/sops.py validate-modules:invalid-documentation  # secret not supported
 tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error

--- a/tests/sanity/ignore-2.20.txt
+++ b/tests/sanity/ignore-2.20.txt
@@ -1,3 +1,5 @@
+plugins/lookup/sops.py validate-modules:invalid-documentation  # secret not supported
+plugins/vars/sops.py validate-modules:invalid-documentation  # secret not supported
 tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error

--- a/tests/sanity/ignore-2.21.txt
+++ b/tests/sanity/ignore-2.21.txt
@@ -1,4 +1,6 @@
+plugins/lookup/sops.py validate-modules:invalid-documentation  # secret not supported
 plugins/module_utils/sops.py pylint:ansible-bad-function
+plugins/vars/sops.py validate-modules:invalid-documentation  # secret not supported
 tests/integration/targets/filter_decrypt/files/hidden-binary.yaml yamllint:error
 tests/integration/targets/filter_decrypt/files/hidden-json.yaml yamllint:error
 tests/integration/targets/lookup_sops/files/hidden-binary.yaml yamllint:error


### PR DESCRIPTION
The Secrets API is being introduced for ansible-core 2.22 and allows modules and plugins to mark secret values for redaction. As opposed to the rudimentary `no_log` handling up until ansible-core 2.21, this improves masking of secret values.

More infos:
* https://forum.ansible.com/t/46291
* https://github.com/ansible/ansible/pull/87457
* https://github.com/ansible/ansible-documentation/pull/3934

Unfortunately, when decrypting structured data, SOPS does not allow to figure out which values were actually encrypted and which ones were not, so we can either only mark *all* values as secret or none. I've opted to mark everything as a secret by default, but there are options per plugin to disable this behavior. For example, vars files or other decrypted config files can contain non-sensitive values (that were not decrypted, but might also have been decrypted) that we definitely do **not** want to be redacted in output.
